### PR TITLE
Update OpenAPI

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vital",
-  "version": "0.15.0-rc7"
+  "version": "0.15.0-rc57"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -15,7 +15,7 @@ groups:
         config:
           namespaceExport: Vital
       - name: fernapi/fern-python-sdk
-        version: 0.5.0-rc2
+        version: 0.6.2
         output:
           location: pypi
           package-name: fern-vital
@@ -25,11 +25,11 @@ groups:
         config:
           client_class_name: Vital
       - name: fernapi/fern-go-sdk
-        version: 0.3.0
+        version: 0.8.0
         github:
           repository: fern-vital/vital-go
       - name: fernapi/fern-java-sdk
-        version: 0.4.9
+        version: 0.5.13
         output:
           location: maven
           coordinate: io.github.fern-api:vital

--- a/fern/openapi/openapi.yml
+++ b/fern/openapi/openapi.yml
@@ -1,362 +1,15 @@
+---
 openapi: 3.1.0
 info:
   title: Vital API
-  description: API for at-home health Wearables and Lab test API for digital health companies.
-  version: 0.1.982
-servers: 
-  - url: https://api.tryvital.io
-    x-fern-server-name: Production
-  - url: https://api.eu.tryvital.io
-    x-fern-server-name: ProductionEU
-  - url: https://api.sandbox.tryvital.io
-    x-fern-server-name: Sandbox
-  - url: https://api.sandbox.eu.tryvital.io
-    x-fern-server-name: SandboxEU    
+  description: API for at-home health Wearables and Lab test API for digital health
+    companies.
+  version: 0.2.86
 paths:
-  /v2/data/webhook/strava/workouts:
-    get:
-      tags:
-        - data-webhook
-      summary: Validate Url
-      description: Validate strava workouts.
-      operationId: validate_url_v2_data_webhook_strava_workouts_get
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: strava
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                title: Response Validate Url V2 Data Webhook Strava Workouts Get
-  /v2/data/webhook/fitbit/workouts:
-    get:
-      tags:
-        - data-webhook
-      summary: Validate Workouts Url Fitbit
-      description: Validate fitbit workouts.
-      operationId: validate_workouts_url_fitbit_v2_data_webhook_fitbit_workouts_get
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: fitbit
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Verify
-          name: verify
-          in: query
-        - required: false
-          schema:
-            type: string
-            format: uuid
-            title: Team Id
-          name: team_id
-          in: query
-      responses:
-        '204':
-          description: Successful Response
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/data/webhook/fitbit/sleep:
-    get:
-      tags:
-        - data-webhook
-      summary: Validate Sleep Url Fitbit
-      description: Validate fitbit workouts.
-      operationId: validate_sleep_url_fitbit_v2_data_webhook_fitbit_sleep_get
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: sleep
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Verify
-          name: verify
-          in: query
-        - required: false
-          schema:
-            type: string
-            format: uuid
-            title: Team Id
-          name: team_id
-          in: query
-      responses:
-        '204':
-          description: Successful Response
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/data/webhook/fitbit/body:
-    get:
-      tags:
-        - data-webhook
-      summary: Validate Body Url Fitbit
-      description: Validate fitbit workouts.
-      operationId: validate_body_url_fitbit_v2_data_webhook_fitbit_body_get
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: body
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Verify
-          name: verify
-          in: query
-        - required: false
-          schema:
-            type: string
-            format: uuid
-            title: Team Id
-          name: team_id
-          in: query
-      responses:
-        '204':
-          description: Successful Response
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/data/webhook/ihealth:
+  "/v2/link/token":
     post:
       tags:
-        - data-webhook
-      summary: Ihealth Webhook
-      description: |-
-        IHealth webhooks return a list of resources that have been updated.
-        For example,
-        [
-            {
-                "CollectionType": "bp",
-                "MDate": "2019-03-01 13:45:01",
-                "UserID": "05dffbe0dd*****",
-                "SubscriptionId": "07bf3c71aa*****"
-            },
-            {
-                "CollectionType": "weight",
-                "MDate": "2019-03-01 13:45:01",
-                "UserID": "05dffbe0dd*****",
-                "SubscriptionId": "07bf3c71aa*****"
-            }
-        ...
-        ]
-
-        Types include:
-            - bp,
-            - glucose,
-            - weight,
-            - activity,
-            - sleep,
-            - spo2,
-            - userinfo,
-            - food,
-            - sport,
-            - temperature,
-            - heartrate
-
-        Returns:
-            200 - Success
-      operationId: ihealth_webhook_v2_data_webhook_ihealth_post
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: ihealth
-      requestBody:
-        content:
-          application/json:
-            schema:
-              title: Body
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Ihealth Webhook V2 Data Webhook Ihealth Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/data/webhook/{provider}/{backfill_type}:
-    post:
-      tags:
-        - data-webhook
-      summary: Receive Resource Updates
-      description: Post records.
-      operationId: receive_resource_updates_v2_data_webhook__provider___backfill_type__post
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: backfill_type
-      parameters:
-        - description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
-          required: true
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/Providers'
-            description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
-          name: provider
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/BackfillType'
-          name: backfill_type
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              anyOf:
-                - type: object
-                - items: {}
-                  type: array
-              title: Body
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Receive Resource Updates V2 Data Webhook  Provider   Backfill Type  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/data/webhook/garmin/workouts/stream:
-    post:
-      tags:
-        - data-webhook
-      summary: Receive Garmin Workout Stream Updates
-      description: Post records.
-      operationId: receive_garmin_workout_stream_updates_v2_data_webhook_garmin_workouts_stream_post
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: garmin
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              title: Body
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Receive Garmin Workout Stream Updates V2 Data Webhook Garmin Workouts Stream Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/data/webhook/deregister/garmin:
-    post:
-      tags:
-        - data-webhook
-      summary: Deregister Garmin
-      description: |-
-        Deregister garmin connected source. This function listens to webhooks from
-        garmin and deregisters a garmin user if a user deresgisters on the
-        garmin website/delinks vital from their garmin account.
-      operationId: deregister_garmin_v2_data_webhook_deregister_garmin_post
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: deregister-garmin
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              title: Data
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Deregister Garmin V2 Data Webhook Deregister Garmin Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/data/webhook/withings:
-    post:
-      tags:
-        - data-webhook
-      summary: Receive Withings Updates
-      operationId: receive_withings_updates_v2_data_webhook_withings_post
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: withings
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Receive Withings Updates V2 Data Webhook Withings Post
-    head:
-      tags:
-        - data-webhook
-      summary: Withings Subscription Created
-      description: Endpoint used by Withings to confirm subscription.
-      operationId: withings_subscription_created_v2_data_webhook_withings_head
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Withings Subscription Created V2 Data Webhook Withings Head
-  /v2/data/webhook/polar:
-    post:
-      tags:
-        - data-webhook
-      summary: Receive Polar Updates
-      operationId: receive_polar_updates_v2_data_webhook_polar_post
-      x-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: polar
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                title: Response Receive Polar Updates V2 Data Webhook Polar Post
-  /v2/link/token:
-    post:
-      tags:
-        - link
+      - link
       summary: Generate Vital Link Token
       description: |-
         Endpoint to generate a user link token, to be used throughout the vital
@@ -366,14 +19,11 @@ paths:
         like to redirect to a custom url after successful or error connection,
         pass in your own custom redirect_url parameter.
       operationId: generate_vital_link_token_v2_link_token_post
-      x-fern-internal: true
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: generate
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LinkTokenExchange'
+              "$ref": "#/components/schemas/LinkTokenExchange"
         required: true
       responses:
         '200':
@@ -381,26 +31,26 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LinkTokenExchangeResponse'
+                "$ref": "#/components/schemas/LinkTokenExchangeResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/token/isValid:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: token
+  "/v2/link/token/isValid":
     post:
       tags:
-        - link
+      - link
       summary: Check Token Valid
       operationId: check_token_valid_v2_link_token_isValid_post
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: check-token
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/LinkTokenBase'
+              "$ref": "#/components/schemas/LinkTokenBase"
         required: true
       responses:
         '200':
@@ -415,101 +65,72 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/code/create:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: is_token_valid
+  "/v2/link/code/create":
     post:
       tags:
-        - link
+      - link
       summary: Create Token
       description: Generate a token to invite a user of Vital mobile app to your team
       operationId: create_token_v2_link_code_create_post
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: create
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User Id
-          name: user_id
-          in: query
-        - required: false
-          schema:
-            type: string
-            format: date-time
-            title: Expires At
-            default: '2023-08-28T19:57:52.555380+00:00'
-          name: expires_at
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+        name: user_id
+        in: query
+      - required: false
+        schema:
+          type: string
+          format: date-time
+          title: Expires At
+          default: '2023-10-30T18:59:18.914985+00:00'
+        name: expires_at
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VitalTokenCreatedResponse'
+                "$ref": "#/components/schemas/VitalTokenCreatedResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/code/exchange:
-    post:
-      tags:
-        - link
-      summary: Exchange Token
-      description: Redeem an invite token for an api key
-      operationId: exchange_token_v2_link_code_exchange_post
+                "$ref": "#/components/schemas/HTTPValidationError"
       x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: exchange-token
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Code
-          name: code
-          in: query
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/VitalTokenExchangeResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/connect/{provider}:
+      x-fern-sdk-method-name: code_create
+  "/v2/link/connect/{provider}":
     get:
       tags:
-        - link
+      - link
       summary: Connect Provider
       description: |-
         REQUEST_SOURCE: VITAL-LINK
         PROVIDER_TYPE: OAUTH
         Connect oauth providers
       operationId: connect_provider_v2_link_connect__provider__get
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: connect-provider
       parameters:
-        - description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
-          required: true
-          schema:
-            type: string
-            title: Provider
-            description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
-          name: provider
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Sdk-No-Redirect
-          name: x-vital-sdk-no-redirect
-          in: header
+      - description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
+        required: true
+        schema:
+          type: string
+          title: Provider
+          description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
+        name: provider
+        in: path
+      - required: false
+        schema:
+          type: string
+          title: X-Vital-Sdk-No-Redirect
+        name: x-vital-sdk-no-redirect
+        in: header
       responses:
         '200':
           description: Successful Response
@@ -523,23 +144,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/start:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: connect_oauth_provider
+  "/v2/link/start":
     post:
       tags:
-        - link
+      - link
       summary: Start Connect Process
       description: |-
         REQUEST_SOURCE: VITAL-LINK
         Start link token process
       operationId: start_connect_process_v2_link_start_post
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: start
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BeginLinkTokenRequest'
+              "$ref": "#/components/schemas/BeginLinkTokenRequest"
         required: true
       responses:
         '200':
@@ -554,18 +175,18 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/state:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: start_connect
+  "/v2/link/state":
     get:
       tags:
-        - link
+      - link
       summary: Check Link Token State
       description: |-
         REQUEST_SOURCE: VITAL-LINK
         Check link token state - can be hit continuously used as heartbeat
       operationId: check_link_token_state_v2_link_state_get
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: state
       responses:
         '200':
           description: Successful Response
@@ -574,23 +195,23 @@ paths:
               schema:
                 type: object
                 title: Response Check Link Token State V2 Link State Get
-  /v2/link/auth/email:
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: token_state
+  "/v2/link/auth/email":
     post:
       tags:
-        - link
+      - link
       summary: Connect Email Auth
       description: |-
         REQUEST_SOURCE: VITAL-LINK
         PROVIDER_TYPE: EMAIL-AUTH
         This function is hit by vital-link to authenticate a email provider.
       operationId: connect_email_auth_v2_link_auth_email_post
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: email-auth
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EmailAuthLink'
+              "$ref": "#/components/schemas/EmailAuthLink"
         required: true
       responses:
         '200':
@@ -598,37 +219,37 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConnectionStatus'
+                "$ref": "#/components/schemas/ConnectionStatus"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/auth:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: email_auth
+  "/v2/link/auth":
     post:
       tags:
-        - link
+      - link
       summary: Connect Password Auth
       description: |-
         REQUEST_SOURCE: VITAL-LINK
         PROVIDER_TYPE: PASSWORD-AUTH
         This function is hit by vital-link to authenticate a password provider.
       operationId: connect_password_auth_v2_link_auth_post
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: auth
       parameters:
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Link-Client-Region
-          name: x-vital-link-client-region
-          in: header
+      - required: false
+        schema:
+          type: string
+          title: X-Vital-Link-Client-Region
+        name: x-vital-link-client-region
+        in: header
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PasswordAuthLink'
+              "$ref": "#/components/schemas/PasswordAuthLink"
         required: true
       responses:
         '200':
@@ -636,69 +257,69 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConnectionStatus'
+                "$ref": "#/components/schemas/ConnectionStatus"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/provider/oauth/{oauth_provider}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: password_auth
+  "/v2/link/provider/oauth/{oauth_provider}":
     get:
       tags:
-        - link
+      - link
       summary: Get Oauth Provider
       description: This endpoint generates an OAuth link for oauth provider
       operationId: get_oauth_provider_v2_link_provider_oauth__oauth_provider__get
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: oauth_provider
       parameters:
-        - required: true
-          schema:
-            $ref: '#/components/schemas/OAuthProviders'
-          name: oauth_provider
-          in: path
+      - required: true
+        schema:
+          "$ref": "#/components/schemas/OAuthProviders"
+        name: oauth_provider
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Source'
+                "$ref": "#/components/schemas/Source"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/provider/password/{provider}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: generate_oauth_link
+  "/v2/link/provider/password/{provider}":
     post:
       tags:
-        - link
+      - link
       summary: Connect Individual Provider
       description: This connects auth providers that are password based.
       operationId: connect_individual_provider_v2_link_provider_password__provider__post
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: password_provider
       parameters:
-        - required: true
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/PasswordProviders'
-            title: Providers that require password auth, whoop, renpho, peloton, zwift
-          name: provider
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Link-Client-Region
-          name: x-vital-link-client-region
-          in: header
+      - required: true
+        schema:
+          allOf:
+          - "$ref": "#/components/schemas/PasswordProviders"
+          title: Providers that require password auth, whoop, renpho, peloton, zwift
+        name: provider
+        in: path
+      - required: false
+        schema:
+          type: string
+          title: X-Vital-Link-Client-Region
+        name: x-vital-link-client-region
+        in: header
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/IndividualProviderData'
+              "$ref": "#/components/schemas/IndividualProviderData"
         required: true
       responses:
         '200':
@@ -706,35 +327,35 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProviderLinkResponse'
+                "$ref": "#/components/schemas/ProviderLinkResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/provider/email/{provider}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: connect_password_provider
+  "/v2/link/provider/email/{provider}":
     post:
       tags:
-        - link
+      - link
       summary: Connect Email Auth Provider
       description: This connects auth providers that are email based.
       operationId: connect_email_auth_provider_v2_link_provider_email__provider__post
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: email_provider
       parameters:
-        - required: true
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/EmailProviders'
-            title: Email providers that require emails freestyle_auth
-          name: provider
-          in: path
+      - required: true
+        schema:
+          allOf:
+          - "$ref": "#/components/schemas/EmailProviders"
+          title: Email providers that require emails freestyle_auth
+        name: provider
+        in: path
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/EmailProviderAuthLink'
+              "$ref": "#/components/schemas/EmailProviderAuthLink"
         required: true
       responses:
         '200':
@@ -742,17 +363,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ConnectionStatus'
+                "$ref": "#/components/schemas/ConnectionStatus"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/providers:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: connect_email_auth_provider
+  "/v2/link/providers":
     get:
       tags:
-        - link
+      - link
       summary: Get Providers
       description: GET List of all available providers given the generated link token.
       operationId: get_providers_v2_link_providers_get
@@ -763,13 +386,13 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/SourceLink'
+                  "$ref": "#/components/schemas/SourceLink"
                 type: array
                 title: Response Get Providers V2 Link Providers Get
-  /v2/link/provider/manual/{provider}:
+  "/v2/link/provider/manual/{provider}":
     post:
       tags:
-        - link
+      - link
       summary: Connect Ble Provider
       description: |-
         REQUEST_SOURCE: CUSTOMER
@@ -777,18 +400,19 @@ paths:
         This connects auth providers that are password based.
       operationId: connect_ble_provider_v2_link_provider_manual__provider__post
       parameters:
-        - required: true
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/ManualProviders'
-            title: Providers that are manually added devices, such as ble devices and generated data
-          name: provider
-          in: path
+      - required: true
+        schema:
+          allOf:
+          - "$ref": "#/components/schemas/ManualProviders"
+          title: Providers that are manually added devices, such as ble devices and
+            generated data
+        name: provider
+        in: path
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ManualConnectionData'
+              "$ref": "#/components/schemas/ManualConnectionData"
         required: true
       responses:
         '200':
@@ -805,22 +429,21 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/link/connect/demo:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: connect_manual_provider
+  "/v2/link/connect/demo":
     post:
       tags:
-        - link
+      - link
       summary: Create Demo Connection
       description: POST Connect the given Vital user to a demo provider.
       operationId: create_demo_connection_v2_link_connect_demo_post
-      x-fern-internal: true 
-      x-fern-sdk-group-name: link
-      x-fern-sdk-method-name: demo
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DemoConnectionCreationPayload'
+              "$ref": "#/components/schemas/DemoConnectionCreationPayload"
         required: true
       responses:
         '200':
@@ -828,980 +451,852 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DemoConnectionStatus'
+                "$ref": "#/components/schemas/DemoConnectionStatus"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/profile/{user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: link
+      x-fern-sdk-method-name: connect_demo_provider
+  "/v2/summary/profile/{user_id}":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Profile
       description: Get Daily profile for user_id
       operationId: get_user_profile_v2_summary_profile__user_id__get
+      parameters:
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ClientFacingProfile"
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/HTTPValidationError"
       x-fern-sdk-group-name: profile
       x-fern-sdk-method-name: get
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientFacingProfile'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    post:
-      tags:
-        - summary
-      summary: Post User Profile
-      operationId: post_user_profile_v2_summary_profile__user_id__post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Ios-Sdk-Version
-          name: x-vital-ios-sdk-version
-          in: header
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Android-Sdk-Version
-          name: x-vital-android-sdk-version
-          in: header
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Post User Profile V2 Summary Profile  User Id  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/profile/{user_id}/raw:
+  "/v2/summary/profile/{user_id}/raw":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Profile Raw
       description: Get Daily profile for user_id
       operationId: get_user_profile_raw_v2_summary_profile__user_id__raw_get
-      x-fern-sdk-group-name: profile
-      x-fern-sdk-method-name: get_raw
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RawProfile'
+                "$ref": "#/components/schemas/RawProfile"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/devices/{user_id}/raw:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: profile
+      x-fern-sdk-method-name: get_raw
+  "/v2/summary/devices/{user_id}/raw":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Devices Raw
       description: Get Devices for user_id
       operationId: get_user_devices_raw_v2_summary_devices__user_id__raw_get
-      x-fern-sdk-group-name: devices
-      x-fern-sdk-method-name: get_raw
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RawDevices'
+                "$ref": "#/components/schemas/RawDevices"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/activity/{user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: devices
+      x-fern-sdk-method-name: get_raw
+  "/v2/summary/activity/{user_id}":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Activity
       description: Get Daily Activity for user_id
       operationId: get_user_activity_v2_summary_activity__user_id__get
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientActivityResponse'
+                "$ref": "#/components/schemas/ClientActivityResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    post:
-      tags:
-        - summary
-      summary: Post User Activity
-      operationId: post_user_activity_v2_summary_activity__user_id__post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Ios-Sdk-Version
-          name: x-vital-ios-sdk-version
-          in: header
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Android-Sdk-Version
-          name: x-vital-android-sdk-version
-          in: header
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Post User Activity V2 Summary Activity  User Id  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/activity/{user_id}/raw:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: activity
+      x-fern-sdk-method-name: get
+  "/v2/summary/activity/{user_id}/raw":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Activity Raw
       description: Get Daily Activity for user_id
       operationId: get_user_activity_raw_v2_summary_activity__user_id__raw_get
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RawActivity'
+                "$ref": "#/components/schemas/RawActivity"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/workouts/{user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: activity
+      x-fern-sdk-method-name: get_raw
+  "/v2/summary/workouts/{user_id}":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Workouts
       description: Get Daily workout for user_id
       operationId: get_user_workouts_v2_summary_workouts__user_id__get
+      parameters:
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ClientWorkoutResponse"
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/HTTPValidationError"
       x-fern-sdk-group-name: workouts
       x-fern-sdk-method-name: get
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientWorkoutResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    post:
-      tags:
-        - summary
-      summary: Post User Workout
-      operationId: post_user_workout_v2_summary_workouts__user_id__post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Ios-Sdk-Version
-          name: x-vital-ios-sdk-version
-          in: header
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Android-Sdk-Version
-          name: x-vital-android-sdk-version
-          in: header
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Post User Workout V2 Summary Workouts  User Id  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/workouts/{user_id}/raw:
+  "/v2/summary/workouts/{user_id}/raw":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Workouts Raw
       description: Get Daily workout for user_id
       operationId: get_user_workouts_raw_v2_summary_workouts__user_id__raw_get
-      x-fern-sdk-group-name: workouts
-      x-fern-sdk-method-name: get_raw
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RawWorkout'
+                "$ref": "#/components/schemas/RawWorkout"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/sleep/{user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: workouts
+      x-fern-sdk-method-name: get_raw
+  "/v2/summary/sleep/{user_id}":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Sleep
       description: Get Daily sleep for user_id
       operationId: get_user_sleep_v2_summary_sleep__user_id__get
+      parameters:
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ClientSleepResponse"
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/HTTPValidationError"
       x-fern-sdk-group-name: sleep
       x-fern-sdk-method-name: get
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientSleepResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    post:
-      tags:
-        - summary
-      summary: Post User Sleep
-      operationId: post_user_sleep_v2_summary_sleep__user_id__post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Ios-Sdk-Version
-          name: x-vital-ios-sdk-version
-          in: header
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Android-Sdk-Version
-          name: x-vital-android-sdk-version
-          in: header
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Post User Sleep V2 Summary Sleep  User Id  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/sleep/{user_id}/stream:
+  "/v2/summary/sleep/{user_id}/stream":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Sleep Stream
       description: Get Daily sleep stream for user_id
       operationId: get_user_sleep_stream_v2_summary_sleep__user_id__stream_get
-      x-fern-sdk-group-name: sleep
-      x-fern-sdk-method-name: get_user_stream
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientSleepResponse'
+                "$ref": "#/components/schemas/ClientSleepResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/sleep/{user_id}/raw:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: sleep
+      x-fern-sdk-method-name: get_stream
+  "/v2/summary/sleep/{user_id}/raw":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Sleep Raw
       description: Get Daily sleep for user_id
       operationId: get_user_sleep_raw_v2_summary_sleep__user_id__raw_get
-      x-fern-sdk-group-name: sleep
-      x-fern-sdk-method-name: get_raw
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RawSleep'
+                "$ref": "#/components/schemas/RawSleep"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/body/{user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: sleep
+      x-fern-sdk-method-name: get_raw
+  "/v2/summary/body/{user_id}":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Body
       description: Get Daily Body data for user_id
       operationId: get_user_body_v2_summary_body__user_id__get
+      parameters:
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ClientBodyResponse"
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/HTTPValidationError"
       x-fern-sdk-group-name: body
       x-fern-sdk-method-name: get
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientBodyResponse'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    post:
-      tags:
-        - summary
-      summary: Post User Body
-      operationId: post_user_body_v2_summary_body__user_id__post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Ios-Sdk-Version
-          name: x-vital-ios-sdk-version
-          in: header
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Android-Sdk-Version
-          name: x-vital-android-sdk-version
-          in: header
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Post User Body V2 Summary Body  User Id  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/body/{user_id}/raw:
+  "/v2/summary/body/{user_id}/raw":
     get:
       tags:
-        - summary
+      - summary
       summary: Get User Body Raw
       description: Get Daily Body data for user_id
       operationId: get_user_body_raw_v2_summary_body__user_id__raw_get
-      x-fern-sdk-group-name: body
-      x-fern-sdk-method-name: get_raw
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RawBody'
+                "$ref": "#/components/schemas/RawBody"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/summary/meal/{user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: body
+      x-fern-sdk-method-name: get_raw
+  "/v2/summary/meal/{user_id}":
     get:
       tags:
-        - summary
+      - summary
       summary: Get Meals
       description: Get user's meals
       operationId: get_meals_v2_summary_meal__user_id__get
-      x-fern-sdk-group-name: meals
-      x-fern-sdk-method-name: get
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingMealResponse'
+                "$ref": "#/components/schemas/ClientFacingMealResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/sleep/{sleep_id}/stream:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: meal
+      x-fern-sdk-method-name: get
+  "/v2/timeseries/sleep/{sleep_id}/stream":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get User Sleep Stream
       description: Get Sleep stream for a user_id
       operationId: get_user_sleep_stream_v2_timeseries_sleep__sleep_id__stream_get
-      x-fern-sdk-group-name: sleep
-      x-fern-sdk-method-name: get_stream
       parameters:
-        - description: The Vital Sleep ID
-          required: true
-          schema:
-            type: string
-            title: Sleep Id
-            description: The Vital Sleep ID
-          name: sleep_id
-          in: path
+      - description: The Vital Sleep ID
+        required: true
+        schema:
+          type: string
+          title: Sleep Id
+          description: The Vital Sleep ID
+        name: sleep_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingSleepStream'
+                "$ref": "#/components/schemas/ClientFacingSleepStream"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/workouts/{workout_id}/stream:
+                "$ref": "#/components/schemas/HTTPValidationError"
+  "/v2/timeseries/workouts/{workout_id}/stream":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get User Workouts
       operationId: get_user_workouts_v2_timeseries_workouts__workout_id__stream_get
-      x-fern-sdk-group-name: workouts
-      x-fern-sdk-method-name: get_stream
       parameters:
-        - description: The Vital ID for the workout
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Workout Id
-            description: The Vital ID for the workout
-          name: workout_id
-          in: path
+      - description: The Vital ID for the workout
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Workout Id
+          description: The Vital ID for the workout
+        name: workout_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingStream'
+                "$ref": "#/components/schemas/ClientFacingStream"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/mindfulness_minutes:
+                "$ref": "#/components/schemas/HTTPValidationError"
+  "/v2/timeseries/{user_id}/mindfulness_minutes":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__mindfulness_minutes_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: mindfulness_minutes
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -1809,62 +1304,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingMindfulnessMinutesTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingMindfulnessMinutesTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Mindfulness Minutes Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Mindfulness
+                  Minutes Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/caffeine:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: mindfulness_minutes
+  "/v2/timeseries/{user_id}/caffeine":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__caffeine_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: caffeine
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -1872,62 +1369,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingCaffeineTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingCaffeineTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Caffeine Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Caffeine
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/water:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: caffeine
+  "/v2/timeseries/{user_id}/water":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__water_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: water
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -1935,125 +1434,129 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingWaterTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingWaterTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Water Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Water
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/steps:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: water
+  "/v2/timeseries/{user_id}/steps":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__steps_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: steps
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
-    responses:
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
+      responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingStepsTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingStepsTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Steps Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Steps
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/floors_climbed:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: steps
+  "/v2/timeseries/{user_id}/floors_climbed":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__floors_climbed_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: floors_climbed
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2061,62 +1564,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingFloorsClimbedTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingFloorsClimbedTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Floors Climbed Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Floors
+                  Climbed Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/distance:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: floors_climbed
+  "/v2/timeseries/{user_id}/distance":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__distance_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: distance
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2124,62 +1629,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingDistanceTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingDistanceTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Distance Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Distance
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/calories_basal:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: distance
+  "/v2/timeseries/{user_id}/calories_basal":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__calories_basal_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: calories_basal
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2187,62 +1694,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingCaloriesBasalTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingCaloriesBasalTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Calories Basal Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Calories
+                  Basal Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/calories_active:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: calories_basal
+  "/v2/timeseries/{user_id}/calories_active":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__calories_active_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: calories_active
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2250,62 +1759,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingCaloriesActiveTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingCaloriesActiveTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Calories Active Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Calories
+                  Active Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/respiratory_rate:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: calories_active
+  "/v2/timeseries/{user_id}/respiratory_rate":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__respiratory_rate_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: respiratory_rate
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2313,62 +1824,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingRespiratoryRateTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingRespiratoryRateTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Respiratory Rate Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Respiratory
+                  Rate Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/ige:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: respiratory_rate
+  "/v2/timeseries/{user_id}/ige":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__ige_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: ige
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2376,62 +1889,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingIgeTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingIgeTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Ige Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Ige
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/igg:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: ige
+  "/v2/timeseries/{user_id}/igg":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__igg_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: igg
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2439,62 +1954,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingIggTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingIggTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Igg Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Igg
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/hypnogram:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: igg
+  "/v2/timeseries/{user_id}/hypnogram":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__hypnogram_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: hypnogram
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2502,62 +2019,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingHypnogramTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingHypnogramTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Hypnogram Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Hypnogram
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/hrv:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: hypnogram
+  "/v2/timeseries/{user_id}/hrv":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__hrv_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: hrv
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2565,62 +2084,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingHRVTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingHRVTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Hrv Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Hrv
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/heartrate:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: hrv
+  "/v2/timeseries/{user_id}/heartrate":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__heartrate_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: heartrate
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2628,62 +2149,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingHeartRateTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingHeartRateTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Heartrate Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Heartrate
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/glucose:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: heartrate
+  "/v2/timeseries/{user_id}/glucose":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__glucose_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: glucose
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2691,62 +2214,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingGlucoseTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingGlucoseTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Glucose Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Glucose
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/cholesterol/triglycerides:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: glucose
+  "/v2/timeseries/{user_id}/cholesterol/triglycerides":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__cholesterol_triglycerides_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: triglycerides
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2754,62 +2279,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingCholesterolTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingCholesterolTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol Triglycerides Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol
+                  Triglycerides Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/cholesterol/total:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: triglycerides
+  "/v2/timeseries/{user_id}/cholesterol/total":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__cholesterol_total_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: cholesterol_total
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2817,62 +2344,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingCholesterolTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingCholesterolTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol Total Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol
+                  Total Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/cholesterol/hdl:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: cholesterol_total
+  "/v2/timeseries/{user_id}/cholesterol/hdl":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__cholesterol_hdl_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: cholesterol_hdl
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2880,62 +2409,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingCholesterolTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingCholesterolTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol Hdl Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol
+                  Hdl Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/cholesterol/ldl:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: cholesterol_hdl
+  "/v2/timeseries/{user_id}/cholesterol/ldl":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__cholesterol_ldl_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: cholesterol_ldl
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -2943,62 +2474,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingCholesterolTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingCholesterolTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol Ldl Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol
+                  Ldl Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/cholesterol:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: cholesterol_ldl
+  "/v2/timeseries/{user_id}/cholesterol":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__cholesterol_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: cholesterol
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -3006,62 +2539,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingCholesterolTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingCholesterolTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Cholesterol
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/blood_oxygen:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: cholesterol
+  "/v2/timeseries/{user_id}/blood_oxygen":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__blood_oxygen_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: blood_oxygen
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -3069,62 +2604,64 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingBloodOxygenTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingBloodOxygenTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Blood Oxygen Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Blood
+                  Oxygen Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/blood_pressure:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: vitals
+      x-fern-sdk-method-name: blood_oxygen
+  "/v2/timeseries/{user_id}/blood_pressure":
     get:
       tags:
-        - timeseries
+      - timeseries
       summary: Get Timeseries Resource Data
       description: Get timeseries data for user
       operationId: get_timeseries_resource_data_v2_timeseries__user_id__blood_pressure_get
-      x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: blood_pressure
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            $ref: '#/components/schemas/TimeseriesResource'
-          name: resource
-          in: query
-        - description: Provider oura/strava etc
-          required: false
-          schema:
-            type: string
-            title: Provider
-            description: Provider oura/strava etc
-            default: ''
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider oura/strava etc
+        required: false
+        schema:
+          type: string
+          title: Provider
+          description: Provider oura/strava etc
+          default: ''
+        name: provider
+        in: query
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: true
+        schema:
+          type: string
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -3132,150 +2669,68 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingBloodPressureTimeseries'
+                  "$ref": "#/components/schemas/ClientFacingBloodPressureTimeseries"
                 type: array
-                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Blood Pressure Get
+                title: Response Get Timeseries Resource Data V2 Timeseries  User Id  Blood
+                  Pressure Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    post:
-      tags:
-        - timeseries
-      summary: Post User Blood Pressure
-      operationId: post_user_blood_pressure_v2_timeseries__user_id__blood_pressure_post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Ios-Sdk-Version
-          name: x-vital-ios-sdk-version
-          in: header
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Android-Sdk-Version
-          name: x-vital-android-sdk-version
-          in: header
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Post User Blood Pressure V2 Timeseries  User Id  Blood Pressure Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/timeseries/{user_id}/{resource}:
-    post:
-      tags:
-        - timeseries
-      summary: Post User Vitals
-      operationId: post_user_vitals_v2_timeseries__user_id___resource__post
+                "$ref": "#/components/schemas/HTTPValidationError"
       x-fern-sdk-group-name: vitals
-      x-fern-sdk-method-name: _timeseries_request
-      parameters:
-        - required: true
-          schema:
-            $ref: '#/components/schemas/IngestibleTimeseriesResource'
-          name: resource
-          in: path
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Ios-Sdk-Version
-          name: x-vital-ios-sdk-version
-          in: header
-        - required: false
-          schema:
-            type: string
-            title: X-Vital-Android-Sdk-Version
-          name: x-vital-android-sdk-version
-          in: header
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Post User Vitals V2 Timeseries  User Id   Resource  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/user:
+      x-fern-sdk-method-name: blood_pressure
+  "/v2/user":
     get:
       tags:
-        - user
+      - user
       summary: Get Teams Users
       description: GET All users for team.
       operationId: get_teams_users_v2_user_get
-      x-fern-sdk-group-name: users
-      x-fern-sdk-method-name: get_all
       parameters:
-        - required: false
-          schema:
-            type: integer
-            title: Offset
-            default: 0
-          name: offset
-          in: query
-        - required: false
-          schema:
-            type: integer
-            maximum: 500
-            title: Limit
-            default: 100
-          name: limit
-          in: query
+      - required: false
+        schema:
+          type: integer
+          title: Offset
+          default: 0
+        name: offset
+        in: query
+      - required: false
+        schema:
+          type: integer
+          maximum: 500
+          title: Limit
+          default: 100
+        name: limit
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedUsersResponse'
+                "$ref": "#/components/schemas/PaginatedUsersResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: get_all
     post:
       tags:
-        - user
+      - user
       summary: Create User
-      description: POST Create a Vital user given a client_user_id and returns the user_id.
+      description: POST Create a Vital user given a client_user_id and returns the
+        user_id.
       operationId: create_user_v2_user_post
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserCreateBody'
+              "$ref": "#/components/schemas/UserCreateBody"
         required: true
       responses:
         '200':
@@ -3283,47 +2738,79 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingUserKey'
+                "$ref": "#/components/schemas/ClientFacingUserKey"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/user/metrics:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: create
+  "/v2/user/metrics":
     get:
       tags:
-        - user
+      - user
       summary: Get Teams Metrics
       description: GET metrics for team.
       operationId: get_teams_metrics_v2_user_metrics_get
-      x-fern-internal: true
-      x-fern-sdk-group-name: users
-      x-fern-sdk-method-name: metrics
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/MetricsResult'
-  /v2/user/providers/{user_id}:
+                "$ref": "#/components/schemas/MetricsResult"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: get_team_metrics
+  "/v2/user/{user_id}/sign_in_token":
+    post:
+      tags:
+      - user
+      summary: Get User Sign In Token
+      operationId: get_user_sign_in_token_v2_user__user_id__sign_in_token_post
+      parameters:
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UserSignInTokenResponse"
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: get_user_sign_in_token
+  "/v2/user/providers/{user_id}":
     get:
       tags:
-        - user
+      - user
       summary: Get Connected Providers
       description: GET Users connected providers
       operationId: get_connected_providers_v2_user_providers__user_id__get
-      x-fern-sdk-group-name: user
-      x-fern-sdk-method-name: providers
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
       responses:
         '200':
           description: Successful Response
@@ -3332,7 +2819,7 @@ paths:
               schema:
                 additionalProperties:
                   items:
-                    $ref: '#/components/schemas/ClientFacingSourceWithStatus'
+                    "$ref": "#/components/schemas/ClientFacingProviderWithStatus"
                   type: array
                 type: object
                 title: Response Get Connected Providers V2 User Providers  User Id  Get
@@ -3341,81 +2828,89 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/user/{user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: get_connected_providers
+  "/v2/user/{user_id}":
     get:
       tags:
-        - user
+      - user
       summary: Get User
       description: GET User details given the user_id.
       operationId: get_user_v2_user__user_id__get
-      x-fern-sdk-group-name: user
-      x-fern-sdk-method-name: get
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingUser'
+                "$ref": "#/components/schemas/ClientFacingUser"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: get
     delete:
       tags:
-        - user
+      - user
       summary: Delete User
       operationId: delete_user_v2_user__user_id__delete
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserSuccessResponse'
+                "$ref": "#/components/schemas/UserSuccessResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: delete
     patch:
       tags:
-        - user
+      - user
       summary: Patch User
       operationId: patch_user_v2_user__user_id__patch
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User Id
-          name: user_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+        name: user_id
+        in: path
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserPatchBody'
+              "$ref": "#/components/schemas/UserPatchBody"
         required: true
       responses:
         '204':
@@ -3425,175 +2920,124 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/user/resolve/{client_user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: patch
+  "/v2/user/resolve/{client_user_id}":
     get:
       tags:
-        - user
+      - user
       summary: Get User By Client User Id
       description: GET user_id from client_user_id.
       operationId: get_user_by_client_user_id_v2_user_resolve__client_user_id__get
-      x-fern-sdk-group-name: users
-      x-fern-sdk-method-name: create
       parameters:
-        - description: A unique ID representing the end user. Typically this will be a user ID number from your application. Personally identifiable information, such as an email address or phone number, should not be used in the client_user_id.
-          required: true
-          schema:
-            type: string
-            title: Client User Id
-            description: A unique ID representing the end user. Typically this will be a user ID number from your application. Personally identifiable information, such as an email address or phone number, should not be used in the client_user_id.
-          name: client_user_id
-          in: path
+      - description: A unique ID representing the end user. Typically this will be
+          a user ID number from your application. Personally identifiable information,
+          such as an email address or phone number, should not be used in the client_user_id.
+        required: true
+        schema:
+          type: string
+          title: Client User Id
+          description: A unique ID representing the end user. Typically this will
+            be a user ID number from your application. Personally identifiable information,
+            such as an email address or phone number, should not be used in the client_user_id.
+        name: client_user_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingUser'
+                "$ref": "#/components/schemas/ClientFacingUser"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/user/{user_id}/{provider}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: get_by_client_user_id
+  "/v2/user/{user_id}/{provider}":
     delete:
       tags:
-        - user
+      - user
       summary: Deregister Provider
       operationId: deregister_provider_v2_user__user_id___provider__delete
-      x-fern-sdk-group-name: user
-      x-fern-sdk-method-name: deregister_provider
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User id returned by vital create user id request. This id should be stored in your database against the user and used for all interactions with the vital api.
-          name: user_id
-          in: path
-        - description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
-          required: true
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/Providers'
-            description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
-          name: provider
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User id returned by vital create user id request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
+        name: user_id
+        in: path
+      - description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
+        required: true
+        schema:
+          allOf:
+          - "$ref": "#/components/schemas/Providers"
+          description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
+        name: provider
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserSuccessResponse'
+                "$ref": "#/components/schemas/UserSuccessResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/user/refresh/{user_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: deregister_provider
+  "/v2/user/refresh/{user_id}":
     post:
       tags:
-        - user
+      - user
       summary: Refresh User Id
       description: Trigger a manual refresh for a specific user
       operationId: refresh_user_id_v2_user_refresh__user_id__post
-      x-fern-sdk-group-name: user
-      x-fern-sdk-method-name: refresh
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User Id
-          name: user_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+        name: user_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserRefreshSuccessResponse'
+                "$ref": "#/components/schemas/UserRefreshSuccessResponse"
                 title: Response Refresh User Id V2 User Refresh  User Id  Post
         '400':
           description: Bad Request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserRefreshErrorResponse'
+                "$ref": "#/components/schemas/UserRefreshErrorResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/user/admin/webhook/{user_id}/{team_id}:
-    post:
-      tags:
-        - user
-      summary: Backfill Webhook For User
-      operationId: backfill_webhook_for_user_v2_user_admin_webhook__user_id___team_id__post
-      x-fern-internal: true
-      x-fern-sdk-group-name: webhook
-      x-fern-sdk-method-name: backfill
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: User Id
-          name: user_id
-          in: path
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: path
-        - required: true
-          schema:
-            type: string
-            title: Provider
-          name: provider
-          in: query
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: true
-          schema:
-            type: string
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Backfill Webhook For User V2 User Admin Webhook  User Id   Team Id  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/link/config:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: user
+      x-fern-sdk-method-name: refresh
+  "/v2/team/link/config":
     get:
       tags:
-        - team
+      - team
       summary: Get Team Config
       description: Post teams.
       operationId: get_team_config_v2_team_link_config_get
@@ -3605,110 +3049,49 @@ paths:
               schema:
                 type: object
                 title: Response Get Team Config V2 Team Link Config Get
-  /v2/team/{team_id}:
+  "/v2/team/{team_id}":
     get:
       tags:
-        - team
+      - team
       summary: Get Team
       description: Get team.
       operationId: get_team_v2_team__team_id__get
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: Team Id
-          name: team_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: Team Id
+        name: team_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingTeam'
+                "$ref": "#/components/schemas/ClientFacingTeam"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    patch:
-      tags:
-        - team
-      summary: Update Team
-      description: Update team.
-      operationId: update_team_v2_team__team_id__patch
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TeamUpdate'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TeamInDB'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/{team_id}/users/count:
+                "$ref": "#/components/schemas/HTTPValidationError"
+  "/v2/team/users/search":
     get:
       tags:
-        - team
-      summary: Get Team User Count
-      description: Get the current user count for a team.
-      operationId: get_team_user_count_v2_team__team_id__users_count_get
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: Team Id
-          name: team_id
-          in: path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: object
-                title: Response Get Team User Count V2 Team  Team Id  Users Count Get
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/users/search:
-    get:
-      tags:
-        - team
+      - team
       summary: Search Team Users By Uuid Or Client User Id
       description: Search team users by user_id
       operationId: search_team_users_by_uuid_or_client_user_id_v2_team_users_search_get
       parameters:
-        - required: false
-          schema:
-            type: string
-            minLength: 2
-            title: Query Id
-          name: query_id
-          in: query
+      - required: false
+        schema:
+          type: string
+          minLength: 2
+          title: Query Id
+        name: query_id
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -3716,245 +3099,20 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingUser'
+                  "$ref": "#/components/schemas/ClientFacingUser"
                 type: array
-                title: Response Search Team Users By Uuid Or Client User Id V2 Team Users Search Get
+                title: Response Search Team Users By Uuid Or Client User Id V2 Team
+                  Users Search Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/{team_id}/apikey:
-    post:
-      tags:
-        - team
-      summary: Create Api Key
-      description: Create api key.
-      operationId: create_api_key_v2_team__team_id__apikey_post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateApiKeyBody'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiKeyInDB'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/{team_id}/apikeys:
+                "$ref": "#/components/schemas/HTTPValidationError"
+  "/v2/team/svix/url":
     get:
       tags:
-        - team
-      summary: Get Api Keys For Team
-      description: Invalidate api key by key value.
-      operationId: get_api_keys_for_team_v2_team__team_id__apikeys_get
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                items:
-                  $ref: '#/components/schemas/ApiKeyInDB'
-                type: array
-                title: Response Get Api Keys For Team V2 Team  Team Id  Apikeys Get
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/{team_id}/apikey/{api_key_id}:
-    delete:
-      tags:
-        - team
-      summary: Delete Api Key
-      description: Invalidate api key by key value.
-      operationId: delete_api_key_v2_team__team_id__apikey__api_key_id__delete
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: path
-        - required: true
-          schema:
-            type: string
-            title: Api Key Id
-          name: api_key_id
-          in: path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiKeyInDB'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-    patch:
-      tags:
-        - team
-      summary: Update Api Key Label
-      description: Update API key label.
-      operationId: update_api_key_label_v2_team__team_id__apikey__api_key_id__patch
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: path
-        - required: true
-          schema:
-            type: string
-            title: Api Key Id
-          name: api_key_id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateApiKeyBody'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiKeyInDB'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/{team_id}/apikey/{api_key_id}/rotate:
-    patch:
-      tags:
-        - team
-      summary: Rotate Api Key
-      description: Deprecated. Rotate api key.
-      operationId: rotate_api_key_v2_team__team_id__apikey__api_key_id__rotate_patch
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: path
-        - required: true
-          schema:
-            type: string
-            title: Api Key Id
-          name: api_key_id
-          in: path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiKeyInDB'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team:
-    post:
-      tags:
-        - team
-      summary: Create Team
-      description: Create Team.
-      operationId: create_team_v2_team_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/TeamCreate'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TeamInDB'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/{team_id}/priority:
-    post:
-      tags:
-        - team
-      summary: Create Priority
-      description: Add Team priority row for source
-      operationId: create_priority_v2_team__team_id__priority_post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: path
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PriorityCreate'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Priority'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/team/svix/url:
-    get:
-      tags:
-        - team
+      - team
       summary: Get Svix Webhook Url
       operationId: get_svix_webhook_url_v2_team_svix_url_get
       responses:
@@ -3965,20 +3123,20 @@ paths:
               schema:
                 type: object
                 title: Response Get Svix Webhook Url V2 Team Svix Url Get
-  /v2/team/source/priorities:
+  "/v2/team/source/priorities":
     get:
       tags:
-        - team
+      - team
       summary: Get Source Priorities
       description: GET source priorities.
       operationId: get_source_priorities_v2_team_source_priorities_get
       parameters:
-        - required: false
-          schema:
-            type: string
-            title: Data Type
-          name: data_type
-          in: query
+      - required: false
+        schema:
+          type: string
+          title: Data Type
+        name: data_type
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -3994,20 +3152,20 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                "$ref": "#/components/schemas/HTTPValidationError"
     patch:
       tags:
-        - team
+      - team
       summary: Update Source Priorities
       description: Patch source priorities.
       operationId: update_source_priorities_v2_team_source_priorities_patch
       parameters:
-        - required: true
-          schema:
-            type: string
-            title: Team Id
-          name: team_id
-          in: query
+      - required: true
+        schema:
+          type: string
+          title: Team Id
+        name: team_id
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -4017,17 +3175,18 @@ paths:
                 items:
                   type: object
                 type: array
-                title: Response Update Source Priorities V2 Team Source Priorities Patch
+                title: Response Update Source Priorities V2 Team Source Priorities
+                  Patch
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v2/providers:
+                "$ref": "#/components/schemas/HTTPValidationError"
+  "/v2/providers":
     get:
       tags:
-        - providers
+      - providers
       summary: Get List Of Providers
       description: Get Provider list
       operationId: get_list_of_providers_v2_providers_get
@@ -4038,43 +3197,16 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingSourceDetailed'
+                  "$ref": "#/components/schemas/ClientFacingProviderDetailed"
                 type: array
                 title: Response Get List Of Providers V2 Providers Get
-  /v2/physician/review/openloop:
-    post:
-      tags:
-        - physician
-      summary: Review Openloop
-      operationId: review_openloop_v2_physician_review_openloop_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/OpenLoopEvent'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                title: Response Review Openloop V2 Physician Review Openloop Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/lab_tests:
+  "/v3/lab_tests":
     get:
       tags:
-        - lab_tests
+      - lab_tests
       summary: Get Lab Tests For Team
       description: GET all the lab tests the team has access to.
       operationId: get_lab_tests_for_team_v3_lab_tests_get
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: get_tests
       responses:
         '200':
           description: Successful Response
@@ -4082,19 +3214,21 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingLabTest'
+                  "$ref": "#/components/schemas/ClientFacingLabTest"
                 type: array
                 title: Response Get Lab Tests For Team V3 Lab Tests Get
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get
     post:
       tags:
-        - lab_tests
+      - lab_tests
       summary: Create Lab Test For Team
       operationId: create_lab_test_for_team_v3_lab_tests_post
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateLabTestRequest'
+              "$ref": "#/components/schemas/CreateLabTestRequest"
         required: true
       responses:
         '200':
@@ -4102,72 +3236,113 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingLabTest'
+                "$ref": "#/components/schemas/ClientFacingLabTest"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/lab_tests/markers:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: create
+  "/v3/lab_tests/markers":
     get:
       tags:
-        - lab_tests
+      - lab_tests
       summary: Get Markers
       description: GET all the markers for the given lab.
       operationId: get_markers_v3_lab_tests_markers_get
       parameters:
-        - description: The identifier Vital assigned to a lab partner.
-          required: false
-          schema:
-            type: integer
-            title: Lab Id
-            description: The identifier Vital assigned to a lab partner.
-          name: lab_id
-          in: query
-        - description: The name of an individual biomarker or a panel. Used as a fuzzy filter when searching markers.
-          required: false
-          schema:
-            type: string
-            title: Name
-            description: The name of an individual biomarker or a panel. Used as a fuzzy filter when searching markers.
-            default: ''
-          name: name
-          in: query
-        - required: false
-          schema:
-            type: integer
-            minimum: 1
-            title: Page
-            default: 1
-          name: page
-          in: query
-        - required: false
-          schema:
-            type: integer
-            maximum: 100
-            minimum: 1
-            title: Size
-            default: 50
-          name: size
-          in: query
+      - description: The identifier Vital assigned to a lab partner.
+        required: false
+        schema:
+          type: integer
+          title: Lab Id
+          description: The identifier Vital assigned to a lab partner.
+        name: lab_id
+        in: query
+      - description: The name of an individual biomarker or a panel. Used as a fuzzy
+          filter when searching markers.
+        required: false
+        schema:
+          type: string
+          title: Name
+          description: The name of an individual biomarker or a panel. Used as a fuzzy
+            filter when searching markers.
+          default: ''
+        name: name
+        in: query
+      - required: false
+        schema:
+          type: integer
+          minimum: 1
+          title: Page
+          default: 1
+        name: page
+        in: query
+      - required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          title: Size
+          default: 50
+        name: size
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetMarkersResponse'
+                "$ref": "#/components/schemas/GetMarkersResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/lab_tests/labs:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_markers
+  "/v3/lab_tests/{lab_id}/markers/{provider_id}":
     get:
       tags:
-        - lab_tests
+      - lab_tests
+      summary: Get Markers By Provider Id
+      description: GET a specific marker for the given lab and provider_id
+      operationId: get_markers_by_provider_id_v3_lab_tests__lab_id__markers__provider_id__get
+      parameters:
+      - required: true
+        schema:
+          type: string
+          title: The provider id assigned by a Lab (e.g Labcorp Id).
+        name: provider_id
+        in: path
+      - required: true
+        schema:
+          type: integer
+          title: The identifier Vital assigned to a lab partner.
+        name: lab_id
+        in: path
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ClientFacingMarker"
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_markers_by_provider_id
+  "/v3/lab_tests/labs":
+    get:
+      tags:
+      - lab_tests
       summary: Get Labs
       description: GET all the labs.
       operationId: get_labs_v3_lab_tests_labs_get
@@ -4178,20 +3353,22 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingLab'
+                  "$ref": "#/components/schemas/ClientFacingLab"
                 type: array
                 title: Response Get Labs V3 Lab Tests Labs Get
-  /v3/order/testkit/register:
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_labs
+  "/v3/order/testkit/register":
     post:
       tags:
-        - order
+      - order
       summary: Register Testkit
       operationId: register_testkit_v3_order_testkit_register_post
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RegisterTestkitRequest'
+              "$ref": "#/components/schemas/RegisterTestkitRequest"
         required: true
       responses:
         '200':
@@ -4199,27 +3376,27 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostOrderResponse'
+                "$ref": "#/components/schemas/PostOrderResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/testkit:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: testkit
+      x-fern-sdk-method-name: register
+  "/v3/order/testkit":
     post:
       tags:
-        - order
+      - order
       summary: Create Testkit Order
       description: Creates an order for an unregistered testkit
       operationId: create_testkit_order_v3_order_testkit_post
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: create_unregistered_testkit_order
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateRegistrableTestkitOrderRequest'
+              "$ref": "#/components/schemas/CreateRegistrableTestkitOrderRequest"
         required: true
       responses:
         '200':
@@ -4227,175 +3404,70 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostOrderResponse'
+                "$ref": "#/components/schemas/PostOrderResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/testkit/process/{team_id}/{order_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: testkit
+      x-fern-sdk-method-name: create_order
+  "/v3/order/phlebotomy/appointment/availability":
     post:
       tags:
-        - order
-      summary: Process Testkit Order
-      description: POST Create shipment for order
-      operationId: process_testkit_order_v3_order_testkit_process__team_id___order_id__post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-          name: order_id
-          in: path
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: Team Id
-          name: team_id
-          in: path
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Process Testkit Order V3 Order Testkit Process  Team Id   Order Id  Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/testkit/status:
-    post:
-      tags:
-        - order
-      summary: Sync Testkit Order Status
-      description: |-
-        This function receives requests from cloud_scheduler
-        and checks the order status of the order if the order status
-        in terms of the inbound delivery and outbound delivery status has
-        changed. If changed then the order status is updated and a webhook
-        is sent to the respective team.
-      operationId: sync_testkit_order_status_v3_order_testkit_status_post
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Sync Testkit Order Status V3 Order Testkit Status Post
-  /v3/order/dispatch/status/checks:
-    post:
-      tags:
-        - order
-      summary: Dispatch Order Status
-      operationId: dispatch_order_status_v3_order_dispatch_status_checks_post
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Dispatch Order Status V3 Order Dispatch Status Checks Post
-  /v3/order/testkit/webhook/shiphero/shipment-update:
-    post:
-      tags:
-        - order
-      summary: Process Testkit Ship Hero Order Shipped
-      operationId: process_testkit_ship_hero_order_shipped_v3_order_testkit_webhook_shiphero_shipment_update_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ShipmentWebhookUpdate'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                type: string
-                title: Response Process Testkit Ship Hero Order Shipped V3 Order Testkit Webhook Shiphero Shipment Update Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/phlebotomy/appointment/availability:
-    post:
-      tags:
-        - order
+      - order
       summary: Get Order Appointment Availability
       description: |-
         Return the available time slots to book an appointment with a phlebotomist
         for the given address and order.
-      operationId: get_order_appointment_availability_v3_order__order_id__phlebotomy_appointment_availability_post
-      x-fern-sdk-group-name: athome_phlebotomy
-      x-fern-sdk-method-name: appointment_availability
-      parameters:
-        - description: Your Order ID.
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-            description: Your Order ID.
-          name: order_id
-          in: path
+      operationId: get_order_appointment_availability_v3_order_phlebotomy_appointment_availability_post
       requestBody:
         content:
           application/json:
             schema:
               allOf:
-                - $ref: '#/components/schemas/USAddress'
+              - "$ref": "#/components/schemas/USAddress"
               title: Address
-              description: At-home phlebotomy appointment address. If None, the address given at the time of placing the order is used.
+              description: At-home phlebotomy appointment address.
+        required: true
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AppointmentAvailabilitySlots'
+                "$ref": "#/components/schemas/AppointmentAvailabilitySlots"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/phlebotomy/appointment/book:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_phlebotomy_appointment_availability
+  "/v3/order/{order_id}/phlebotomy/appointment/book":
     post:
       tags:
-        - order
+      - order
       summary: Book Phlebotomy Appointment
       description: Book an at-home phlebotomy appointment.
       operationId: book_phlebotomy_appointment_v3_order__order_id__phlebotomy_appointment_book_post
-      x-fern-sdk-group-name: athome_phlebotomy
-      x-fern-sdk-method-name: book_appointment
       parameters:
-        - description: Your Order ID.
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-            description: Your Order ID.
-          name: order_id
-          in: path
+      - description: Your Order ID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+          description: Your Order ID.
+        name: order_id
+        in: path
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppointmentBookingRequest'
+              "$ref": "#/components/schemas/AppointmentBookingRequest"
         required: true
       responses:
         '200':
@@ -4403,37 +3475,37 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingAppointment'
+                "$ref": "#/components/schemas/ClientFacingAppointment"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/phlebotomy/appointment/reschedule:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: book_phlebotomy_appointment
+  "/v3/order/{order_id}/phlebotomy/appointment/reschedule":
     patch:
       tags:
-        - order
+      - order
       summary: Reschedule Phlebotomy Appointment
       description: Reschedule a previously booked at-home phlebotomy appointment.
       operationId: reschedule_phlebotomy_appointment_v3_order__order_id__phlebotomy_appointment_reschedule_patch
-      x-fern-sdk-group-name: athome_phlebotomy
-      x-fern-sdk-method-name: reschedule_appointment
       parameters:
-        - description: Your Order ID.
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-            description: Your Order ID.
-          name: order_id
-          in: path
+      - description: Your Order ID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+          description: Your Order ID.
+        name: order_id
+        in: path
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppointmentRescheduleRequest'
+              "$ref": "#/components/schemas/AppointmentRescheduleRequest"
         required: true
       responses:
         '200':
@@ -4441,37 +3513,37 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingAppointment'
+                "$ref": "#/components/schemas/ClientFacingAppointment"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/phlebotomy/appointment/cancel:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: reschedule_phlebotomy_appointment
+  "/v3/order/{order_id}/phlebotomy/appointment/cancel":
     patch:
       tags:
-        - order
+      - order
       summary: Cancel Phlebotomy Appointment
       description: Cancel a previously booked at-home phlebotomy appointment.
       operationId: cancel_phlebotomy_appointment_v3_order__order_id__phlebotomy_appointment_cancel_patch
-      x-fern-sdk-group-name: athome_phlebotomy
-      x-fern-sdk-method-name: cancel_appointment
       parameters:
-        - description: Your Order ID.
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-            description: Your Order ID.
-          name: order_id
-          in: path
+      - description: Your Order ID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+          description: Your Order ID.
+        name: order_id
+        in: path
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppointmentCancelRequest'
+              "$ref": "#/components/schemas/AppointmentCancelRequest"
         required: true
       responses:
         '200':
@@ -4479,22 +3551,22 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingAppointment'
+                "$ref": "#/components/schemas/ClientFacingAppointment"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/phlebotomy/appointment/cancellation-reasons:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: cancel_phlabotomy_appointment
+  "/v3/order/phlebotomy/appointment/cancellation-reasons":
     get:
       tags:
-        - order
+      - order
       summary: Get Phlebotomy Appointment Cancellation Reasons
       description: Get the list of reasons for cancelling an at-home phlebotomy appointment.
       operationId: get_phlebotomy_appointment_cancellation_reasons_v3_order_phlebotomy_appointment_cancellation_reasons_get
-      x-fern-sdk-group-name: athome_phlebotomy
-      x-fern-sdk-method-name: cancellation_reason
       responses:
         '200':
           description: Successful Response
@@ -4502,45 +3574,48 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingAppointmentCancellationReason'
+                  "$ref": "#/components/schemas/ClientFacingAppointmentCancellationReason"
                 type: array
-                title: Response Get Phlebotomy Appointment Cancellation Reasons V3 Order Phlebotomy Appointment Cancellation Reasons Get
-  /v3/order/{order_id}/phlebotomy/appointment:
+                title: Response Get Phlebotomy Appointment Cancellation Reasons V3
+                  Order Phlebotomy Appointment Cancellation Reasons Get
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_phlebotomy_appointment_cancellation_reason
+  "/v3/order/{order_id}/phlebotomy/appointment":
     get:
       tags:
-        - order
+      - order
       summary: Get Phlebotomy Appointment
       description: Get the appointment associated with an order.
       operationId: get_phlebotomy_appointment_v3_order__order_id__phlebotomy_appointment_get
-      x-fern-sdk-group-name: athome_phlebotomy
-      x-fern-sdk-method-name: get_appointment
       parameters:
-        - description: Your Order ID.
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-            description: Your Order ID.
-          name: order_id
-          in: path
+      - description: Your Order ID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+          description: Your Order ID.
+        name: order_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingAppointment'
+                "$ref": "#/components/schemas/ClientFacingAppointment"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/area/info:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_phlebotomy_appointment
+  "/v3/order/area/info":
     get:
       tags:
-        - order
+      - order
       summary: Get Area Info
       description: |-
         GET information about an area with respect to lab-testing.
@@ -4548,142 +3623,141 @@ paths:
         Information returned:
         * Whether a given zip code is served by our Phlebotomy network.
       operationId: get_area_info_v3_order_area_info_get
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: get_area_info
       parameters:
-        - description: Zip code of the area to check
-          required: true
-          schema:
-            type: string
-            pattern: ^\d{5}$
-            title: Zip Code
-            description: Zip code of the area to check
-          name: zip_code
-          in: query
+      - description: Zip code of the area to check
+        required: true
+        schema:
+          type: string
+          pattern: "^\\d{5}$"
+          title: Zip Code
+          description: Zip code of the area to check
+        name: zip_code
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AreaInfo'
+                "$ref": "#/components/schemas/AreaInfo"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/result/pdf:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_area_info
+  "/v3/order/{order_id}/result/pdf":
     get:
       tags:
-        - order
+      - order
       summary: Get Lab Test Result
       description: This endpoint returns the lab results for the order.
       operationId: get_lab_test_result_v3_order__order_id__result_pdf_get
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: get_results_pdf
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-          name: order_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+        name: order_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                title: Response Get Lab Test Result V3 Order  Order Id  Result Pdf Get
+                title: Response Get Lab Test Result V3 Order  Order Id  Result Pdf
+                  Get
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/result/metadata:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_result_pdf
+  "/v3/order/{order_id}/result/metadata":
     get:
       tags:
-        - order
+      - order
       summary: Get Lab Test Result Metadata
       description: |-
         Return metadata related to order results, such as lab metadata,
         provider and sample dates.
       operationId: get_lab_test_result_metadata_v3_order__order_id__result_metadata_get
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: get_results_metadata
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-          name: order_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+        name: order_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LabResultsMetadata'
+                "$ref": "#/components/schemas/LabResultsMetadata"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/result:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_result_metadata
+  "/v3/order/{order_id}/result":
     get:
       tags:
-        - order
+      - order
       summary: Get Lab Test Result Raw
       description: Return both metadata and raw json test data
       operationId: get_lab_test_result_raw_v3_order__order_id__result_get
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: get_results
       parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-          name: order_id
-          in: path
+      - required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+        name: order_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LabResultsRaw'
+                "$ref": "#/components/schemas/LabResultsRaw"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/requisition/pdf:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_result_raw
+  "/v3/order/{order_id}/requisition/pdf":
     get:
       tags:
-        - order
+      - order
       summary: Get Order Requisition Url
       description: GET requisition pdf for an order
       operationId: get_order_requisition_url_v3_order__order_id__requisition_pdf_get
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: get
       parameters:
-        - description: Your Order ID.
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-            description: Your Order ID.
-          name: order_id
-          in: path
+      - description: Your Order ID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+          description: Your Order ID.
+        name: order_id
+        in: path
       responses:
         '200':
           description: Successful Response
@@ -4695,53 +3769,53 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_order_requistion_pdf
+  "/v3/order/{order_id}":
     get:
       tags:
-        - order
+      - order
       summary: Get Order
       description: GET individual order by ID.
       operationId: get_order_v3_order__order_id__get
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: get_order
       parameters:
-        - description: Your Order ID.
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-            description: Your Order ID.
-          name: order_id
-          in: path
+      - description: Your Order ID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+          description: Your Order ID.
+        name: order_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ClientFacingOrder'
+                "$ref": "#/components/schemas/ClientFacingOrder"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_order
+  "/v3/order":
     post:
       tags:
-        - order
+      - order
       summary: Create Order
       description: POST create new order
       operationId: create_order_v3_order_post
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: create_order
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateOrderRequestCompatible'
+              "$ref": "#/components/schemas/CreateOrderRequestCompatible"
         required: true
       responses:
         '200':
@@ -4749,95 +3823,58 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostOrderResponse'
+                "$ref": "#/components/schemas/PostOrderResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/cancel:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: create_order
+  "/v3/order/{order_id}/cancel":
     post:
       tags:
-        - order
+      - order
       summary: Cancel Order
       description: POST cancel order
       operationId: cancel_order_v3_order__order_id__cancel_post
       parameters:
-        - description: Your Order ID.
-          required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-            description: Your Order ID.
-          name: order_id
-          in: path
+      - description: Your Order ID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Order Id
+          description: Your Order ID.
+        name: order_id
+        in: path
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostOrderResponse'
+                "$ref": "#/components/schemas/PostOrderResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/order/{order_id}/test:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: cancel_order
+  "/v3/insurance/search/payor":
     post:
       tags:
-        - order
-      summary: Order Process Simulate
-      description: Get available test kits.
-      operationId: order_process_simulate_v3_order__order_id__test_post
-      parameters:
-        - required: true
-          schema:
-            type: string
-            format: uuid
-            title: Order Id
-          name: order_id
-          in: path
-        - required: false
-          schema:
-            $ref: '#/components/schemas/OrderStatus'
-          name: final_status
-          in: query
-        - required: false
-          schema:
-            type: integer
-            title: Delay
-          name: delay
-          in: query
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                title: Response Order Process Simulate V3 Order  Order Id  Test Post
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/insurance/search/payor:
-    post:
-      tags:
-        - insurance
+      - insurance
       summary: Search Insurance Payor Information
       operationId: search_insurance_payor_information_v3_insurance_search_payor_post
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: search_payor
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PayorSearchRequest'
+              "$ref": "#/components/schemas/PayorSearchRequest"
         required: true
       responses:
         '200':
@@ -4846,30 +3883,31 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingPayorSearchResponse'
+                  "$ref": "#/components/schemas/ClientFacingPayorSearchResponse"
                 type: array
-                title: Response Search Insurance Payor Information V3 Insurance Search Payor Post
+                title: Response Search Insurance Payor Information V3 Insurance Search
+                  Payor Post
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/insurance/search/diagnosis:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: insurance
+      x-fern-sdk-method-name: search_payor_info
+  "/v3/insurance/search/diagnosis":
     get:
       tags:
-        - insurance
+      - insurance
       summary: Search Diagnosis
       operationId: search_diagnosis_v3_insurance_search_diagnosis_get
-      x-fern-sdk-group-name: lab_tests
-      x-fern-sdk-method-name: search_diagnosis
       parameters:
-        - required: true
-          schema:
-            type: string
-            title: Diagnosis Query
-          name: diagnosis_query
-          in: query
+      - required: true
+        schema:
+          type: string
+          title: Diagnosis Query
+        name: diagnosis_query
+        in: query
       responses:
         '200':
           description: Successful Response
@@ -4877,7 +3915,7 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: '#/components/schemas/ClientFacingDiagnosisInformation'
+                  "$ref": "#/components/schemas/ClientFacingDiagnosisInformation"
                 type: array
                 title: Response Search Diagnosis V3 Insurance Search Diagnosis Get
         '422':
@@ -4885,120 +3923,101 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /v3/orders:
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: insurance
+      x-fern-sdk-method-name: search_diagnosis
+  "/v3/orders":
     get:
       tags:
-        - orders
+      - orders
       summary: Get Orders
       description: GET many orders with filters.
       operationId: get_orders_v3_orders_get
       parameters:
-        - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          required: false
-          schema:
-            type: string
-            format: date-time
-            title: Start Date
-            description: Date from in YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 00:00:00
-          name: start_date
-          in: query
-        - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          required: false
-          schema:
-            type: string
-            format: date-time
-            title: End Date
-            description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided without a time, the time will be set to 23:59:59
-          name: end_date
-          in: query
-        - description: Filter by user ID.
-          required: false
-          schema:
+      - description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+          is provided without a time, the time will be set to 00:00:00
+        required: false
+        schema:
+          type: string
+          format: date-time
+          title: Start Date
+          description: Date from in YYYY-MM-DD or ISO formatted date time. If a date
+            is provided without a time, the time will be set to 00:00:00
+        name: start_date
+        in: query
+      - description: Date to YYYY-MM-DD or ISO formatted date time. If a date is provided
+          without a time, the time will be set to 23:59:59
+        required: false
+        schema:
+          type: string
+          format: date-time
+          title: End Date
+          description: Date to YYYY-MM-DD or ISO formatted date time. If a date is
+            provided without a time, the time will be set to 23:59:59
+        name: end_date
+        in: query
+      - description: Filter by user ID.
+        required: false
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+          description: Filter by user ID.
+        name: user_id
+        in: query
+      - description: Filter by patient name.
+        required: false
+        schema:
+          type: string
+          title: Patient Name
+          description: Filter by patient name.
+        name: patient_name
+        in: query
+      - description: Filter by order ids.
+        required: false
+        schema:
+          items:
             type: string
             format: uuid
-            title: User Id
-            description: Filter by user ID.
-          name: user_id
-          in: query
-        - description: Filter by patient name.
-          required: false
-          schema:
-            type: string
-            title: Patient Name
-            description: Filter by patient name.
-          name: patient_name
-          in: query
-        - description: Filter by order ids.
-          required: false
-          schema:
-            items:
-              type: string
-              format: uuid
-            type: array
-            title: Order Ids
-            description: Filter by order ids.
-          name: order_ids
-          in: query
-        - required: false
-          schema:
-            type: integer
-            minimum: 1
-            title: Page
-            default: 1
-          name: page
-          in: query
-        - required: false
-          schema:
-            type: integer
-            maximum: 100
-            minimum: 1
-            title: Size
-            default: 50
-          name: size
-          in: query
+          type: array
+          title: Order Ids
+          description: Filter by order ids.
+        name: order_ids
+        in: query
+      - required: false
+        schema:
+          type: integer
+          minimum: 1
+          title: Page
+          default: 1
+        name: page
+        in: query
+      - required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          title: Size
+          default: 50
+        name: size
+        in: query
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetOrdersResponse'
+                "$ref": "#/components/schemas/GetOrdersResponse"
         '422':
           description: Validation Error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /robots.txt:
-    get:
-      summary: Robots
-      operationId: robots_robots_txt_get
-      x-internal: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            text/plain:
-              schema:
-                type: string
-security: 
-  - apiKeyAuth: []
+                "$ref": "#/components/schemas/HTTPValidationError"
+      x-fern-sdk-group-name: lab_tests
+      x-fern-sdk-method-name: get_orders
 components:
-  securitySchemes:
-    apiKeyAuth:
-      type: apiKey
-      in: header
-      name: x-vital-api-key
-      description: API key based authentication
   schemas:
-    APIKeyRole:
-      type: string
-      enum:
-        - vital_admin
-        - default
-      title: APIKeyRole
-      description: An enumeration.
     ActivityV2InDB:
       properties:
         timestamp:
@@ -5027,16 +4046,16 @@ components:
           format: uuid4
           title: Id
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingProvider"
       type: object
       required:
-        - timestamp
-        - provider_id
-        - user_id
-        - source_id
-        - priority_id
-        - id
-        - source
+      - timestamp
+      - provider_id
+      - user_id
+      - source_id
+      - priority_id
+      - id
+      - source
       title: ActivityV2InDB
     Address:
       properties:
@@ -5061,65 +4080,26 @@ components:
           title: State
       type: object
       required:
-        - first_line
-        - country
-        - zip
-        - city
-        - state
+      - first_line
+      - country
+      - zip
+      - city
+      - state
       title: Address
-    ApiKeyInDB:
-      properties:
-        label:
-          type: string
-          title: Label
-        value:
-          type: string
-          title: Value
-        team_id:
-          type: string
-          format: uuid
-          title: Team Id
-        id:
-          type: string
-          format: uuid
-          title: Id
-        in_app:
-          type: boolean
-          title: In App
-        created_at:
-          type: string
-          format: date-time
-          title: Created At
-        deleted_at:
-          type: string
-          format: date-time
-          title: Deleted At
-        role:
-          $ref: '#/components/schemas/APIKeyRole'
-      type: object
-      required:
-        - label
-        - value
-        - team_id
-        - id
-        - in_app
-        - created_at
-        - role
-      title: ApiKeyInDB
     AppointmentAvailabilitySlots:
       properties:
         slots:
           items:
-            $ref: '#/components/schemas/DaySlots'
+            "$ref": "#/components/schemas/DaySlots"
           type: array
           title: Slots
         timezone:
           type: string
-          pattern: ^(?:[a-zA-Z]+\/[a-zA-Z_]+)$
+          pattern: "^(?:[a-zA-Z]+\\/[a-zA-Z_]+)$"
           title: Timezone
       type: object
       required:
-        - slots
+      - slots
       title: AppointmentAvailabilitySlots
     AppointmentBookingRequest:
       properties:
@@ -5128,7 +4108,7 @@ components:
           title: Booking Key
       type: object
       required:
-        - booking_key
+      - booking_key
       title: AppointmentBookingRequest
       description: |-
         Pydantic BaseModel that supports `hidden` field property.
@@ -5145,13 +4125,22 @@ components:
           title: Notes
       type: object
       required:
-        - cancellation_reason_id
+      - cancellation_reason_id
       title: AppointmentCancelRequest
+    AppointmentEventStatus:
+      type: string
+      enum:
+      - scheduled
+      - completed
+      - cancelled
+      - in_progress
+      title: AppointmentEventStatus
+      description: An enumeration.
     AppointmentProvider:
       type: string
       enum:
-        - getlabs
-        - axlehealth
+      - getlabs
+      - axlehealth
       title: AppointmentProvider
       description: An enumeration.
     AppointmentRescheduleRequest:
@@ -5161,7 +4150,7 @@ components:
           title: Booking Key
       type: object
       required:
-        - booking_key
+      - booking_key
       title: AppointmentRescheduleRequest
       description: |-
         Pydantic BaseModel that supports `hidden` field property.
@@ -5170,98 +4159,51 @@ components:
     AppointmentStatus:
       type: string
       enum:
-        - confirmed
-        - pending
-        - in_progress
-        - completed
-        - cancelled
+      - confirmed
+      - pending
+      - in_progress
+      - completed
+      - cancelled
       title: AppointmentStatus
       description: An enumeration.
     AppointmentType:
       type: string
       enum:
-        - phlebotomy
+      - phlebotomy
       title: AppointmentType
       description: An enumeration.
     AreaInfo:
       properties:
         zip_code:
           type: string
-          pattern: ^\d{5}$
+          pattern: "^\\d{5}$"
           title: Zip Code
         phlebotomy:
-          $ref: '#/components/schemas/PhlebotomyAreaInfo'
+          "$ref": "#/components/schemas/PhlebotomyAreaInfo"
       type: object
       required:
-        - zip_code
-        - phlebotomy
+      - zip_code
+      - phlebotomy
       title: AreaInfo
     AuthType:
       type: string
       enum:
-        - password
-        - oauth
-        - email
+      - password
+      - oauth
+      - email
       title: AuthType
       description: An enumeration.
-    BackfillType:
-      type: string
-      enum:
-        - workouts
-        - activity
-        - sleep
-        - body
-        - workout_stream
-        - sleep_stream
-        - profile
-        - blood_pressure
-        - blood_oxygen
-        - glucose
-        - heartrate
-        - heartrate_variability
-        - weight
-        - fat
-        - meal
-        - water
-        - caffeine
-        - mindfulness_minutes
-        - calories_active
-        - distance
-        - steps
-        - respiratory_rate
-        - vo2_max
-        - stress
-        - garmin_epoch
-        - withings_intraday
-        - polar_physical_info
-      title: BackfillType
-      description: |-
-        Vital internal resource type
-
-        See `ClientFacingResource` and `TimeseriesResource` for the client-facing nouns.
-
-        This is not intended to be a client-facing classification, but rather a set of
-        common nouns to coordinate provider code resources, and infra resources like Pub/Sub.
-
-        Each noun could have different meanings for different providers, and therefore could
-        be producing different set of client facing resources. There is no strict 1-to-1
-        relationship.
-
-        For example, the "activity" resource of HealthKit produces not only ClientFacingActivity,
-        but also various kinds of data samples like steps, calories_basal, etc. Meanwhile,
-        the "activity" resource of Fitbit produces only ClientFacingActivity; the activity intraday
-        data are separately produced by the dedicated resources, e.g., "distance", "steps".
     BeginLinkTokenRequest:
       properties:
         link_token:
           type: string
           title: Link Token
         provider:
-          $ref: '#/components/schemas/Providers'
+          "$ref": "#/components/schemas/Providers"
       type: object
       required:
-        - link_token
-        - provider
+      - link_token
+      - provider
       title: BeginLinkTokenRequest
     BiomarkerResult:
       properties:
@@ -5275,6 +4217,11 @@ components:
         value:
           type: number
           title: Value
+        result:
+          type: string
+          title: Result
+        type:
+          "$ref": "#/components/schemas/ResultType"
         unit:
           type: string
           title: Unit
@@ -5297,10 +4244,16 @@ components:
         is_below_min_range:
           type: boolean
           title: Is Below Min Range
+        interpretation:
+          type: string
+          title: Interpretation
+          default: normal
       type: object
       required:
-        - name
-        - value
+      - name
+      - value
+      - result
+      - type
       title: BiomarkerResult
       description: Represent the schema for an individual biomarker result.
     BodyV2InDB:
@@ -5331,79 +4284,86 @@ components:
           format: uuid
           title: Id
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingProvider"
         priority:
           type: integer
           title: Priority
       type: object
       required:
-        - timestamp
-        - provider_id
-        - user_id
-        - source_id
-        - id
+      - timestamp
+      - provider_id
+      - user_id
+      - source_id
+      - id
       title: BodyV2InDB
     ClientActivityResponse:
       properties:
         activity:
           items:
-            $ref: '#/components/schemas/ClientFacingActivity'
+            "$ref": "#/components/schemas/ClientFacingActivity"
           type: array
           title: Activity
       type: object
       required:
-        - activity
+      - activity
       title: Daily Activity
       example:
         activity:
-          - date: '2023-08-28T19:42:32.820850+00:00'
-            calendar_date: '2023-08-28'
-            calories_total: 100
-            calories_active: 2000
-            steps: 10000
-            daily_movement: 200
-            low: 6400
-            medium: 6400
-            high: 6000
-            floors_climbed: 10
-            time_zone: Europe/London
-            timezone_offset: 3600
-            source:
-              name: Oura
-              slug: oura
-              logo: https://logo_url.com
-            user_id: 88f3c8e4-84d0-41db-8ba9-c7a53f5658ac
+        - date: '2023-10-30T18:44:09+00:00'
+          calendar_date: '2023-10-30'
+          calories_total: 100
+          calories_active: 2000
+          steps: 10000
+          daily_movement: 200
+          low: 6400
+          medium: 6400
+          high: 6000
+          floors_climbed: 10
+          timezone_offset: 3600
+          time_zone: Europe/London
+          heart_rate:
+            avg_bpm: 80
+            min_bpm: 60
+            max_bpm: 100
+            resting_bpm: 60
+          source:
+            name: Oura
+            slug: oura
+            logo: https://logo_url.com
+          user_id: e51b0a4f-865a-443f-b8ef-5d440b73cb82
     ClientBodyResponse:
       properties:
         body:
           items:
-            $ref: '#/components/schemas/ClientFacingBody'
+            "$ref": "#/components/schemas/ClientFacingBody"
           type: array
           title: Body
       type: object
       required:
-        - body
+      - body
       title: ClientBodyResponse
       example:
         body:
-          - id: 07a362ad-bb92-43bc-bb54-5b560f0f929e
-            date: '2023-08-28T19:42:39.656855+00:00'
-            calendar_date: 2023-42-
-            weight: 80
-            fat: 30
-            height: 183
-            source:
-              name: Oura
-              slug: oura
-              logo: https://logo_url.com
-            user_id: 3d8e941c-aaaa-4673-b211-1ca1a1679df9
+        - id: c5041aa6-e251-4ee2-a472-d112715ab781
+          date: '2023-10-30T18:44:12+00:00'
+          calendar_date: 2023-44-
+          weight: 80
+          fat: 30
+          height: 183
+          source:
+            name: Oura
+            slug: oura
+            logo: https://logo_url.com
+          user_id: d91b091e-b2c9-4ba1-8e72-a69fac244a91
     ClientFacingActivity:
       properties:
         user_id:
           type: string
           format: uuid
           title: User Id
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         id:
           type: string
           format: uuid
@@ -5412,7 +4372,8 @@ components:
           type: string
           format: date-time
           title: Date
-          description: Date of the specified record, formatted as ISO8601 datetime string in UTC 00:00. Deprecated in favour of calendar_date.
+          description: Date of the specified record, formatted as ISO8601 datetime
+            string in UTC 00:00. Deprecated in favour of calendar_date.
           deprecated: true
         calendar_date:
           type: string
@@ -5422,11 +4383,13 @@ components:
         calories_total:
           type: number
           title: Calories Total
-          description: Total energy consumption during the day including Basal Metabolic Rate in kilocalories::kilocalories
+          description: Total energy consumption during the day including Basal Metabolic
+            Rate in kilocalories::kilocalories
         calories_active:
           type: number
           title: Calories Active
-          description: Energy consumption caused by the physical activity of the day in kilocalories::kilocalories
+          description: Energy consumption caused by the physical activity of the day
+            in kilocalories::kilocalories
         steps:
           type: integer
           title: Steps
@@ -5434,28 +4397,31 @@ components:
         daily_movement:
           type: number
           title: Daily Movement
-          description: Deprecated. Daily physical activity as equal meters i.e. amount of walking needed to get the same amount of activity::meters
+          description: Deprecated. Daily physical activity as equal meters i.e. amount
+            of walking needed to get the same amount of activity::meters
           deprecated: true
         distance:
           type: number
           title: Distance
-          description: Cumulated distance for exercise
-          default: []
+          description: Distance traveled during activities throughout the day::meters
         low:
           type: number
           title: Low
-          description: Number of minutes during the day with low intensity activity (e.g. household work)::minutes
+          description: Number of minutes during the day with low intensity activity
+            (e.g. household work)::minutes
         medium:
           type: number
           title: Medium
-          description: Number of minutes during the day with medium intensity activity (e.g. walking)::minutes
+          description: Number of minutes during the day with medium intensity activity
+            (e.g. walking)::minutes
         high:
           type: number
           title: High
-          description: Number of minutes during the day with high intensity activity (e.g. running)::minutes
+          description: Number of minutes during the day with high intensity activity
+            (e.g. running)::minutes
         source:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingSource'
+          - "$ref": "#/components/schemas/ClientFacingSource"
           title: Source
           description: Source the data has come from.
         floors_climbed:
@@ -5465,27 +4431,30 @@ components:
         time_zone:
           type: string
           title: Time Zone
-          description: '[DEPRECATED] The time zone full identifier for the data. Example: ''Europe/London''.'
+          description: "[DEPRECATED] The time zone full identifier for the data. Example:
+            'Europe/London'."
         timezone_offset:
           type: integer
           title: Timezone Offset
-          description: Timezone offset from UTC as seconds. For example, EEST (Eastern European Summer Time, +3h) is 10800. PST (Pacific Standard Time, -8h) is -28800::seconds
+          description: Timezone offset from UTC as seconds. For example, EEST (Eastern
+            European Summer Time, +3h) is 10800. PST (Pacific Standard Time, -8h)
+            is -28800::seconds
         heart_rate:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingHeartRate'
+          - "$ref": "#/components/schemas/ClientFacingHeartRate"
           title: Heart Rate
           description: Heart rate daily summary.
       type: object
       required:
-        - user_id
-        - id
-        - date
-        - calendar_date
-        - source
+      - user_id
+      - id
+      - date
+      - calendar_date
+      - source
       title: Daily Activity
       example:
-        date: '2023-08-28T19:42:32.816284+00:00'
-        calendar_date: '2023-08-28'
+        date: '2023-10-30T18:44:09+00:00'
+        calendar_date: '2023-10-30'
         calories_total: 100
         calories_active: 2000
         steps: 10000
@@ -5505,7 +4474,7 @@ components:
           name: Oura
           slug: oura
           logo: https://logo_url.com
-        user_id: c73df827-1b65-424f-883c-2dae9cb9f8de
+        user_id: e51b0a4f-865a-443f-b8ef-5d440b73cb82
     ClientFacingApiKey:
       properties:
         label:
@@ -5532,10 +4501,10 @@ components:
           title: Deleted At
       type: object
       required:
-        - label
-        - value
-        - id
-        - created_at
+      - label
+      - value
+      - id
+      - created_at
       title: ClientFacingApiKey
     ClientFacingAppointment:
       properties:
@@ -5547,52 +4516,72 @@ components:
           type: string
           format: uuid4
           title: User Id
+        order_id:
+          type: string
+          format: uuid4
+          title: Order Id
         address:
-          $ref: '#/components/schemas/USAddress'
+          "$ref": "#/components/schemas/USAddress"
         location:
-          $ref: '#/components/schemas/LngLat'
+          "$ref": "#/components/schemas/LngLat"
         start_at:
           type: string
           format: date-time
           title: Start At
+          description: Time is in UTC
         end_at:
           type: string
           format: date-time
           title: End At
+          description: Time is in UTC
         iana_timezone:
           type: string
-          pattern: ^(?:[a-zA-Z]+\/[a-zA-Z_]+)$
+          pattern: "^(?:[a-zA-Z]+\\/[a-zA-Z_]+)$"
           title: Iana Timezone
         type:
-          $ref: '#/components/schemas/AppointmentType'
+          "$ref": "#/components/schemas/AppointmentType"
         provider:
-          $ref: '#/components/schemas/AppointmentProvider'
+          "$ref": "#/components/schemas/AppointmentProvider"
         status:
-          $ref: '#/components/schemas/AppointmentStatus'
+          "$ref": "#/components/schemas/AppointmentStatus"
         provider_id:
           type: string
           title: Provider Id
         can_reschedule:
           type: boolean
           title: Can Reschedule
+        event_status:
+          "$ref": "#/components/schemas/AppointmentEventStatus"
+        event_data:
+          type: object
+          title: Event Data
+        events:
+          items:
+            "$ref": "#/components/schemas/ClientFacingAppointmentEvent"
+          type: array
+          title: Events
       type: object
       required:
-        - id
-        - user_id
-        - address
-        - location
-        - start_at
-        - end_at
-        - iana_timezone
-        - type
-        - provider
-        - status
-        - provider_id
-        - can_reschedule
+      - id
+      - user_id
+      - order_id
+      - address
+      - location
+      - start_at
+      - end_at
+      - iana_timezone
+      - type
+      - provider
+      - status
+      - provider_id
+      - can_reschedule
+      - event_status
+      - events
       title: ClientFacingAppointment
       example:
-        id: d165a968-a31d-4d95-b911-93ecb89f1830
-        user_id: d879353d-3c08-48ef-8492-e2b115ff745f
+        id: b5dc34dc-006d-4f2e-b626-2f83899445be
+        user_id: de55ccd8-21b2-4f83-9135-edc77c03a17a
+        order_id: 49b0ac43-0f33-410a-8270-c2db8a7ebac2
         address:
           first_line: 123 Main St.
           second_line: Apt. 208
@@ -5603,14 +4592,23 @@ components:
         location:
           lng: -122.4194155
           lat: 37.7749295
-        start_at: '2021-01-01T00:00:00'
-        end_at: '2021-01-01T00:00:00'
+        start_at: '2022-01-01T00:00:00'
+        end_at: '2022-01-01T00:00:00'
         iana_timezone: America/New_York
         type: phlebotomy
         provider: getlabs
         status: confirmed
+        event_status: scheduled
         provider_id: '123'
         can_reschedule: true
+        event_data:
+          description: Metadata field containing provider specific data, like cancellation
+            reason or origin
+        events:
+        - created_at: '2022-01-01T00:00:00Z'
+          status: scheduled
+        - created_at: '2022-01-02T00:00:00Z'
+          status: completed
     ClientFacingAppointmentCancellationReason:
       properties:
         id:
@@ -5625,14 +4623,30 @@ components:
           title: Is Refundable
       type: object
       required:
-        - id
-        - name
-        - is_refundable
+      - id
+      - name
+      - is_refundable
       title: ClientFacingAppointmentCancellationReason
       example:
-        id: 39de0e45-3ccf-4e91-85bf-20872a7bce5d
+        id: 9e7ee89f-59ba-4d21-af88-d27167db3b3f
         name: I'm feeling sick
         is_refundable: true
+    ClientFacingAppointmentEvent:
+      properties:
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        status:
+          "$ref": "#/components/schemas/AppointmentEventStatus"
+        data:
+          type: object
+          title: Data
+      type: object
+      required:
+      - created_at
+      - status
+      title: ClientFacingAppointmentEvent
     ClientFacingAtHomePhlebotomyOrder:
       properties:
         id:
@@ -5654,17 +4668,17 @@ components:
           title: Updated At
       type: object
       required:
-        - id
-        - created_at
-        - updated_at
+      - id
+      - created_at
+      - updated_at
       title: ClientFacingAtHomePhlebotomyOrder
       description: |-
         Schema for a at-home-phlebotomy test order in the client facing API.
 
         To be used as part of a ClientFacingOrder.
       example:
-        id: be9d921a-2c3f-4528-97e3-310b83649107
-        appointment_id: 241b0b90-2c10-4892-9e7c-5b7a457cafa9
+        id: e8a48fd8-6d39-4f4c-9290-8c25df92fe0b
+        appointment_id: 59717fd9-d0c2-4527-ab6e-35692a19d436
         created_at: '2020-01-01T00:00:00Z'
         updated_at: '2020-01-01T00:00:00Z'
     ClientFacingAtHomePhlebotomyOrderDetails:
@@ -5672,90 +4686,97 @@ components:
         type:
           type: string
           enum:
-            - at_home_phlebotomy
+          - at_home_phlebotomy
           title: Type
         data:
-          $ref: '#/components/schemas/ClientFacingAtHomePhlebotomyOrder'
+          "$ref": "#/components/schemas/ClientFacingAtHomePhlebotomyOrder"
       type: object
       required:
-        - type
+      - type
       title: ClientFacingAtHomePhlebotomyOrderDetails
     ClientFacingBloodOxygenTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in percentage (spo2).
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: The value of the measurement.
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in percentage (spo2).
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingBloodOxygenTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610390+00:00'
+        timestamp: '2023-10-30T18:44:11.463637+00:00'
         value: 98
-        type: thumb_reading
-        unit: percent
+        unit: "%"
     ClientFacingBloodPressureTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id, note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: The unit of the value. We use SI units where possible, e.g.
+            mmol/L for glucose/cholesterol, bpm for heart rate, etc.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         systolic:
           type: number
           title: Systolic
         diastolic:
           type: number
           title: Diastolic
-        type:
-          type: string
-          title: Type
-        unit:
-          type: string
-          title: Unit
       type: object
       required:
-        - timestamp
-        - systolic
-        - diastolic
-        - unit
+      - unit
+      - timestamp
+      - systolic
+      - diastolic
       title: ClientFacingBloodPressureTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.761355+00:00'
+        timestamp: '2023-10-30T18:44:11+00:00'
         systolic: '125'
         diastolic: '75'
-        type: cuff
         unit: mmHg
     ClientFacingBody:
       properties:
@@ -5763,7 +4784,9 @@ components:
           type: string
           format: uuid
           title: User Id
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         id:
           type: string
           format: uuid
@@ -5772,7 +4795,8 @@ components:
           type: string
           format: date-time
           title: Date
-          description: Date of the specified record, formatted as ISO8601 datetime string in UTC 00:00. Deprecated in favour of calendar_date.
+          description: Date of the specified record, formatted as ISO8601 datetime
+            string in UTC 00:00. Deprecated in favour of calendar_date.
           deprecated: true
         calendar_date:
           type: string
@@ -5788,19 +4812,19 @@ components:
           title: Fat
           description: Body fat percentage::perc
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingSource"
       type: object
       required:
-        - user_id
-        - id
-        - date
-        - calendar_date
-        - source
+      - user_id
+      - id
+      - date
+      - calendar_date
+      - source
       title: ClientFacingBody
       example:
-        id: dbc36fc9-b32d-4400-acda-54cd148ff7b6
-        date: '2023-08-28T19:42:39.654671+00:00'
-        calendar_date: 2023-42-
+        id: c5041aa6-e251-4ee2-a472-d112715ab781
+        date: '2023-10-30T18:44:12+00:00'
+        calendar_date: 2023-44-
         weight: 80
         fat: 30
         height: 183
@@ -5808,175 +4832,213 @@ components:
           name: Oura
           slug: oura
           logo: https://logo_url.com
-        user_id: 7e91072d-a0dc-4555-a807-cac8e2947456
+        user_id: d91b091e-b2c9-4ba1-8e72-a69fac244a91
     ClientFacingCaffeineTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
-        timestamp:
-          type: string
-          format: date-time
-          title: Timestamp
-          description: The timestamp of the measurement.
+          description: Deprecated
         timezone_offset:
           type: integer
           title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
-        value:
-          type: number
-          title: Value
-          description: Quantity of caffeine consumed during the time period.
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
         type:
           type: string
           title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
         unit:
           type: string
           title: Unit
           description: Measured in grams.
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+          description: Depracated. The start time (inclusive) of the interval.
+        start:
+          type: string
+          format: date-time
+          title: Start
+          description: The start time (inclusive) of the interval.
+        end:
+          type: string
+          format: date-time
+          title: End
+          description: The end time (exclusive) of the interval.
+        value:
+          type: number
+          title: Value
+          description: Quantity of caffeine consumed during the time period.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - start
+      - end
+      - value
       title: ClientFacingCaffeineTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610486+00:00'
+        timestamp: '2023-10-30T18:44:11.465420+00:00'
+        start: '2023-10-30T18:44:11.465496+00:00'
+        end: '2023-10-30T18:49:11.465604+00:00'
         value: 42
-        type: automatic
         unit: g
     ClientFacingCaloriesActiveTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          enum:
+          - kcal
+          title: Unit
+          description: Measured in kilocalories (kcal)
         timestamp:
           type: string
           format: date-time
           title: Timestamp
-          description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
+          description: Depracated. The start time (inclusive) of the interval.
+        start:
+          type: string
+          format: date-time
+          title: Start
+          description: The start time (inclusive) of the interval.
+        end:
+          type: string
+          format: date-time
+          title: End
+          description: The end time (exclusive) of the interval.
         value:
           type: number
           title: Value
-          description: Energy consumption caused by the physical activity at the time or interval::kilocalories
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          enum:
-            - kcal
-          title: Unit
-          description: Measured in kilocalories (kcal)
+          description: Energy consumption caused by the physical activity at the time
+            or interval::kilocalories
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - start
+      - end
+      - value
       title: ClientFacingCaloriesActiveTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610523+00:00'
+        timestamp: '2023-10-30T18:44:11.466314+00:00'
+        start: '2023-10-30T18:44:11.466440+00:00'
+        end: '2023-10-30T18:49:11.466557+00:00'
         value: 184
-        type: automatic
         unit: kcal
     ClientFacingCaloriesBasalTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          enum:
+          - kcal
+          title: Unit
+          description: Measured in kilocalories (kcal)
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: Basal Metabolic Rate at the time or interval::kilocalories
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          enum:
-            - kcal
-          title: Unit
-          description: Measured in kilocalories (kcal)
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingCaloriesBasalTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610537+00:00'
+        timestamp: '2023-10-30T18:44:11.466693+00:00'
         value: 22.8
-        type: automatic
         unit: kcal
     ClientFacingCholesterolTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in mmol/L.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: The value of the measurement.
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in mmol/L.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingCholesterolTimeseries
       example:
-        - timestamp: '2023-08-28T19:42:37.610285+00:00'
-          value: 0.6
-          type: cholesterol/ldl
-          unit: mmol/L
-        - timestamp: '2023-08-28T19:42:37.610306+00:00'
-          value: 0.2
-          type: cholesterol/hdl
-          unit: mmol/L
-        - timestamp: '2023-08-28T19:42:37.610322+00:00'
-          value: 0.7
-          type: cholesterol/total
-          unit: mmol/L
-        - timestamp: '2023-08-28T19:42:37.610341+00:00'
-          value: 0.7
-          type: cholesterol/triglycerides
-          unit: mmol/L
+      - timestamp: '2023-10-30T18:44:11.462535+00:00'
+        value: 0.6
+        type: cholesterol/ldl
+        unit: mmol/L
+      - timestamp: '2023-10-30T18:44:11.462651+00:00'
+        value: 0.2
+        type: cholesterol/hdl
+        unit: mmol/L
+      - timestamp: '2023-10-30T18:44:11.462805+00:00'
+        value: 0.7
+        type: cholesterol/total
+        unit: mmol/L
+      - timestamp: '2023-10-30T18:44:11.462900+00:00'
+        value: 0.7
+        type: cholesterol/triglycerides
+        unit: mmol/L
     ClientFacingDiagnosisInformation:
       properties:
         diagnosis_code:
@@ -5989,124 +5051,155 @@ components:
           description: Diagnosis description insurance information required by Labcorp.
       type: object
       required:
-        - diagnosis_code
-        - description
+      - diagnosis_code
+      - description
       title: ClientFacingDiagnosisInformation
     ClientFacingDistanceTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          enum:
+          - m
+          title: Unit
+          description: Measured in meters (m)
         timestamp:
           type: string
           format: date-time
           title: Timestamp
-          description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
+          description: Depracated. The start time (inclusive) of the interval.
+        start:
+          type: string
+          format: date-time
+          title: Start
+          description: The start time (inclusive) of the interval.
+        end:
+          type: string
+          format: date-time
+          title: End
+          description: The end time (exclusive) of the interval.
         value:
           type: number
           title: Value
           description: Distance traveled during activities at the time or interval::steps
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          enum:
-            - m
-          title: Unit
-          description: Measured in meters (m)
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - start
+      - end
+      - value
       title: ClientFacingDistanceTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610549+00:00'
+        timestamp: '2023-10-30T18:44:11.466844+00:00'
+        start: '2023-10-30T18:44:11.466931+00:00'
+        end: '2023-10-30T18:49:11.467316+00:00'
         value: 5.6
-        type: automatic
         unit: m
     ClientFacingFloorsClimbedTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          enum:
+          - count
+          title: Unit
+          description: Measured in counts
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: Number of floors climbed at the time or interval::count
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          enum:
-            - count
-          title: Unit
-          description: Measured in counts
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingFloorsClimbedTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610561+00:00'
+        timestamp: '2023-10-30T18:44:11.467415+00:00'
         value: 2
-        type: automatic
         unit: count
+    ClientFacingFood:
+      properties:
+        energy:
+          "$ref": "#/components/schemas/Energy"
+        macros:
+          "$ref": "#/components/schemas/Macros"
+        micros:
+          "$ref": "#/components/schemas/Micros"
+      type: object
+      title: ClientFacingFood
     ClientFacingGlucoseTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in mmol/L.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: The value of the measurement.
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in mmol/L.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingGlucoseTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610235+00:00'
+        timestamp: '2023-10-30T18:44:11.462159+00:00'
         value: 0.5
         type: automatic | manual_scan
         unit: mmol/L
@@ -6115,38 +5208,40 @@ components:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in rmssd.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: HRV calculated using rmssd during sleep
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in rmssd.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingHRVTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610371+00:00'
+        timestamp: '2023-10-30T18:44:11.463433+00:00'
         value: 48
-        type: automatic
         unit: rmssd
     ClientFacingHeartRate:
       properties:
@@ -6178,112 +5273,134 @@ components:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in bpm.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: Heart rate in bpm
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in bpm.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingHeartRateTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610357+00:00'
+        timestamp: '2023-10-30T18:44:11.463002+00:00'
         value: 70
-        type: automatic
         unit: bpm
     ClientFacingHypnogramTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
-        timestamp:
-          type: string
-          format: date-time
-          title: Timestamp
-          description: The timestamp of the measurement.
+          description: Deprecated
         timezone_offset:
           type: integer
           title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
-        value:
-          type: number
-          title: Value
-          description: 'Hypnogram for sleep stages {"deep": 1, "light": 2, "rem": 3, "awake": 4, "manual": 5, "missing_data": -1}'
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
         type:
           type: string
           title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
         unit:
           type: string
           title: Unit
           description: 'enum: 1: deep, 2: light, 3: rem, 4: awake, -1: missing_data.'
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+          description: Depracated. The start time (inclusive) of the interval.
+        start:
+          type: string
+          format: date-time
+          title: Start
+          description: The start time (inclusive) of the interval.
+        end:
+          type: string
+          format: date-time
+          title: End
+          description: The end time (exclusive) of the interval.
+        value:
+          type: number
+          title: Value
+          description: 'Hypnogram for sleep stages {"deep": 1, "light": 2, "rem":
+            3, "awake": 4, "manual": 5, "missing_data": -1}'
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - start
+      - end
+      - value
       title: ClientFacingHypnogramTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610460+00:00'
+        timestamp: '2023-10-30T18:44:11.464887+00:00'
+        start: '2023-10-30T18:44:11.464978+00:00'
+        end: '2023-10-30T18:49:11.465167+00:00'
         value: 1
-        type: automatic
         unit: stage
     ClientFacingIgeTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in FSU.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: The value of the measurement.
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in FSU.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingIgeTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610406+00:00'
+        timestamp: '2023-10-30T18:44:11.464351+00:00'
         value: 70
         type: baha_grass
         unit: FSU
@@ -6292,36 +5409,39 @@ components:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in FSU.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: The value of the measurement.
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in FSU.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingIggTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610421+00:00'
+        timestamp: '2023-10-30T18:44:11.464471+00:00'
         value: 12
         type: dairy
         unit: FSU
@@ -6347,22 +5467,22 @@ components:
           title: Zipcode
         collection_methods:
           items:
-            $ref: '#/components/schemas/LabTestCollectionMethod'
+            "$ref": "#/components/schemas/LabTestCollectionMethod"
           type: array
         sample_types:
           items:
-            $ref: '#/components/schemas/LabTestSampleType'
+            "$ref": "#/components/schemas/LabTestSampleType"
           type: array
       type: object
       required:
-        - id
-        - slug
-        - name
-        - first_line_address
-        - city
-        - zipcode
-        - collection_methods
-        - sample_types
+      - id
+      - slug
+      - name
+      - first_line_address
+      - city
+      - zipcode
+      - collection_methods
+      - sample_types
       title: ClientFacingLab
       example:
         id: 1
@@ -6372,9 +5492,9 @@ components:
         city: San Francisco
         zipcode: '91789'
         sample_types:
-          - saliva
+        - saliva
         collection_methods:
-          - testkit
+        - testkit
     ClientFacingLabTest:
       properties:
         id:
@@ -6388,9 +5508,9 @@ components:
           type: string
           title: Name
         sample_type:
-          $ref: '#/components/schemas/LabTestSampleType'
+          "$ref": "#/components/schemas/LabTestSampleType"
         method:
-          $ref: '#/components/schemas/LabTestCollectionMethod'
+          "$ref": "#/components/schemas/LabTestCollectionMethod"
         price:
           type: number
           title: Price
@@ -6400,29 +5520,31 @@ components:
         fasting:
           type: boolean
           title: Fasting
-          description: Defines whether a lab test requires fasting. Only available for Labcorp.
+          description: Defines whether a lab test requires fasting. Only available
+            for Labcorp.
           default: false
         lab:
-          $ref: '#/components/schemas/ClientFacingLab'
+          "$ref": "#/components/schemas/ClientFacingLab"
         markers:
           items:
-            $ref: '#/components/schemas/ClientFacingMarker'
+            "$ref": "#/components/schemas/ClientFacingMarker"
           type: array
           title: Markers
         is_delegated:
           type: boolean
           title: Is Delegated
-          description: Denotes whether a lab test requires using non-Vital physician networks. If it does then it's delegated - no otherwise.
+          description: Denotes whether a lab test requires using non-Vital physician
+            networks. If it does then it's delegated - no otherwise.
           default: false
       type: object
       required:
-        - id
-        - slug
-        - name
-        - sample_type
-        - method
-        - price
-        - is_active
+      - id
+      - slug
+      - name
+      - sample_type
+      - method
+      - price
+      - is_active
       title: ClientFacingLabTest
       example:
         lab_test:
@@ -6441,9 +5563,9 @@ components:
             city: New York
             zipcode: '10001'
           markers:
-            - name: Thyroid Stimulating Hormone
-              slug: tsh
-              description: ''
+          - name: Thyroid Stimulating Hormone
+            slug: tsh
+            description: ''
     ClientFacingMarker:
       properties:
         id:
@@ -6465,7 +5587,7 @@ components:
           type: string
           title: Provider Id
         type:
-          $ref: '#/components/schemas/MarkerType'
+          "$ref": "#/components/schemas/MarkerType"
         unit:
           type: string
           title: Unit
@@ -6474,115 +5596,132 @@ components:
           title: Price
       type: object
       required:
-        - id
-        - name
-        - slug
+      - id
+      - name
+      - slug
       title: ClientFacingMarker
       example:
         id: 1
         name: Hemoglobin A1c
         slug: hemoglobin-a1c
-        description: Hemoglobin A1c is a form of hemoglobin that is measured identify your average blood sugar levels over the past 3 months.
+        description: Hemoglobin A1c is a form of hemoglobin that is measured identify
+          your average blood sugar levels over the past 3 months.
         lab_id: 1
         provider_id: '1234'
         type: biomarker
-        unit: '%'
+        unit: "%"
         price: '10.00'
     ClientFacingMealResponse:
       properties:
         meals:
           items:
-            $ref: '#/components/schemas/MealInDBBase_ClientFacingSource_'
+            "$ref": "#/components/schemas/MealInDBBase_ClientFacingSource_"
           type: array
           title: Meals
       type: object
       required:
-        - meals
+      - meals
       title: ClientFacingMealResponse
       example:
         meals:
-          - id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
-            user_id: a169451c-8525-4352-b8ca-070dd449a1a5
-            priority_id: 42
-            source_id: 10
-            provider_id: '123456'
-            timestamp: '2019-08-24T14:15:22Z'
-            name: Dinner
-            data:
-              Chiken coquet starter:
-                energy:
-                  unit: kcal
-                  value: 400
-                macros:
-                  carbs: 75
-                  protein: 10
-                  fats:
-                    saturated: 98
-                    monounsaturated: 1
-                    polyunsaturated: 1
-                    omega3: 0
-                    omega6: 0
-                    total: 100
-                  sugar: 25
-                micros:
-                  minerals:
-                    sodium: 500
-              Coffee, black, 1 tbsp(s):
-                energy:
-                  unit: kcal
-                  value: 0
-                macros:
-                  carbs: 0
-                  protein: 0
-                  fats:
-                    total: 0
-                  sugar: 0
-                micros:
-                  minerals:
-                    sodium: 0
-            source:
-              name: MyFitnessPal
-              slug: my_fitness_pal
-              logo: https://logo_url.com
-            created_at: '2019-08-24T14:15:22Z'
-            updated_at: '2019-08-24T14:15:22Z'
+        - id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
+          user_id: a169451c-8525-4352-b8ca-070dd449a1a5
+          priority_id: 42
+          source_id: 10
+          provider_id: '123456'
+          timestamp: '2019-08-24T14:15:22Z'
+          name: Dinner
+          data:
+            Chiken coquet starter:
+              energy:
+                unit: kcal
+                value: 400
+              macros:
+                carbs: 75
+                protein: 10
+                fats:
+                  saturated: 98
+                  monounsaturated: 1
+                  polyunsaturated: 1
+                  omega3: 0
+                  omega6: 0
+                  total: 100
+                sugar: 25
+              micros:
+                minerals:
+                  sodium: 500
+            Coffee, black, 1 tbsp(s):
+              energy:
+                unit: kcal
+                value: 0
+              macros:
+                carbs: 0
+                protein: 0
+                fats:
+                  total: 0
+                sugar: 0
+              micros:
+                minerals:
+                  sodium: 0
+          source:
+            name: MyFitnessPal
+            slug: my_fitness_pal
+            logo: https://logo_url.com
+          created_at: '2019-08-24T14:15:22Z'
+          updated_at: '2019-08-24T14:15:22Z'
     ClientFacingMindfulnessMinutesTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
-        timestamp:
-          type: string
-          format: date-time
-          title: Timestamp
-          description: The timestamp of the measurement.
+          description: Deprecated
         timezone_offset:
           type: integer
           title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
-        value:
-          type: number
-          title: Value
-          description: Number of minutes spent in a mindful state.
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
         type:
           type: string
           title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
         unit:
           type: string
           title: Unit
           description: Measured in minutes.
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+          description: Depracated. The start time (inclusive) of the interval.
+        start:
+          type: string
+          format: date-time
+          title: Start
+          description: The start time (inclusive) of the interval.
+        end:
+          type: string
+          format: date-time
+          title: End
+          description: The end time (exclusive) of the interval.
+        value:
+          type: number
+          title: Value
+          description: Number of minutes spent in a mindful state.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - start
+      - end
+      - value
       title: ClientFacingMindfulnessMinutesTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610498+00:00'
+        timestamp: '2023-10-30T18:44:11.465683+00:00'
+        start: '2023-10-30T18:44:11.465777+00:00'
+        end: '2023-10-30T18:49:11.465848+00:00'
         value: 42
-        type: automatic
         unit: min
     ClientFacingOrder:
       properties:
@@ -6590,7 +5729,9 @@ components:
           type: string
           format: uuid
           title: User Id
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         id:
           type: string
           format: uuid
@@ -6603,24 +5744,24 @@ components:
           description: Your team id.
         patient_details:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingPatientDetailsCompatible'
+          - "$ref": "#/components/schemas/ClientFacingPatientDetailsCompatible"
           title: Patient Details
           description: Patient Details
         patient_address:
           allOf:
-            - $ref: '#/components/schemas/PatientAddressCompatible'
+          - "$ref": "#/components/schemas/PatientAddressCompatible"
           title: Patient Address
           description: Patient Address
         lab_test:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingLabTest'
+          - "$ref": "#/components/schemas/ClientFacingLabTest"
           title: Lab Test
           description: The Vital Test associated with the order
         details:
           anyOf:
-            - $ref: '#/components/schemas/ClientFacingWalkInOrderDetails'
-            - $ref: '#/components/schemas/ClientFacingTestKitOrderDetails'
-            - $ref: '#/components/schemas/ClientFacingAtHomePhlebotomyOrderDetails'
+          - "$ref": "#/components/schemas/ClientFacingWalkInOrderDetails"
+          - "$ref": "#/components/schemas/ClientFacingTestKitOrderDetails"
+          - "$ref": "#/components/schemas/ClientFacingAtHomePhlebotomyOrderDetails"
           title: Details
         sample_id:
           type: string
@@ -6639,16 +5780,16 @@ components:
           type: string
           format: date-time
           title: Updated At
-          description: When your order was last updated
+          description: When your order was last updated.
         events:
           items:
-            $ref: '#/components/schemas/ClientFacingOrderEvent'
+            "$ref": "#/components/schemas/ClientFacingOrderEvent"
           type: array
           title: Events
         status:
-          $ref: '#/components/schemas/OrderTopLevelStatus'
+          "$ref": "#/components/schemas/OrderTopLevelStatus"
         physician:
-          $ref: '#/components/schemas/PhysicianClientFacing'
+          "$ref": "#/components/schemas/PhysicianClientFacing"
         health_insurance_id:
           type: string
           format: uuid
@@ -6661,28 +5802,29 @@ components:
         priority:
           type: boolean
           title: Priority
-          description: Defines whether order is priority or not. Only available for Labcorp. For Labcorp, this corresponds to a STAT order.
+          description: Defines whether order is priority or not. Only available for
+            Labcorp. For Labcorp, this corresponds to a STAT order.
           default: false
         shipping_details:
           allOf:
-            - $ref: '#/components/schemas/ShippingAddress'
+          - "$ref": "#/components/schemas/ShippingAddress"
           title: Shipping Details
           description: Shipping Details. For unregistered testkit orders.
       type: object
       required:
-        - user_id
-        - id
-        - team_id
-        - lab_test
-        - details
-        - created_at
-        - updated_at
-        - events
+      - user_id
+      - id
+      - team_id
+      - lab_test
+      - details
+      - created_at
+      - updated_at
+      - events
       title: ClientFacingOrder
       example:
-        id: b66f3949-6390-4061-b001-28e69ab408eb
-        team_id: 6959b71e-9eb2-41d5-affc-f0c9d130d3d5
-        user_id: 20cef1ad-09c4-4752-88d7-5472e64c6073
+        id: 40e93660-bf7c-4130-bf94-28d6d8402830
+        team_id: 46bcb1eb-2de6-4166-b97a-cdd3954740dc
+        user_id: e51a28ca-c8d5-42d8-9db9-3b1b2ebaa3a6
         patient_details:
           dob: '2020-01-01'
           gender: male
@@ -6694,20 +5836,20 @@ components:
           state: CA
           zip: '91189'
           country: United States
-          phone_number: '+11234567890'
+          phone_number: "+11234567890"
         details:
           type: testkit
           data:
             id: a655f0e4-6405-4a1d-80b7-66f06c2108a7
             shipment:
               id: d55210cc-3d9f-4115-8262-5013f700c7be
-              outbound_tracking_number: <outbound_tracking_number>
-              outbound_tracking_url: <outbound_tracking_url>
-              inbound_tracking_number: <inbound_tracking_number>
-              inbound_tracking_url: <inbound_tracking_url>
+              outbound_tracking_number: "<outbound_tracking_number>"
+              outbound_tracking_url: "<outbound_tracking_url>"
+              inbound_tracking_number: "<inbound_tracking_number>"
+              inbound_tracking_url: "<inbound_tracking_url>"
               outbound_courier: usps
               inbound_courier: usps
-              notes: <notes>
+              notes: "<notes>"
               created_at: '2020-01-01T00:00:00.000Z'
               updated_at: '2020-01-01T00:00:00.000Z'
             created_at: '2020-01-01T00:00:00Z'
@@ -6717,22 +5859,22 @@ components:
           description: Cholesterol test
           method: testkit
         sample_id: '123456789'
-        health_insurace_id: 52f8bdd4-f666-48ef-9dde-5e6c71c8d012
+        health_insurace_id: 31228cbc-af9d-4b0a-9469-0586607c35fa
         requisition_form_url: https://www.example.com
         notes: This is a note
         created_at: '2020-01-01T00:00:00Z'
         updated_at: '2020-01-01T00:00:00Z'
         status: collecting_sample
         events:
-          - id: 1
-            created_at: '2022-01-01T00:00:00Z'
-            status: received.testkit.ordered
-          - id: 2
-            created_at: '2022-01-02T00:00:00Z'
-            status: received.testkit.requisition_created
-          - id: 3
-            created_at: '2022-01-03T00:00:00Z'
-            status: collecting_sample.testkit.transit_customer
+        - id: 1
+          created_at: '2022-01-01T00:00:00Z'
+          status: received.testkit.ordered
+        - id: 2
+          created_at: '2022-01-02T00:00:00Z'
+          status: received.testkit.requisition_created
+        - id: 3
+          created_at: '2022-01-03T00:00:00Z'
+          status: collecting_sample.testkit.transit_customer
     ClientFacingOrderEvent:
       properties:
         id:
@@ -6743,12 +5885,12 @@ components:
           format: date-time
           title: Created At
         status:
-          $ref: '#/components/schemas/OrderStatus'
+          "$ref": "#/components/schemas/OrderStatus"
       type: object
       required:
-        - id
-        - created_at
-        - status
+      - id
+      - created_at
+      - status
       title: ClientFacingOrderEvent
     ClientFacingPatientDetailsCompatible:
       properties:
@@ -6773,29 +5915,32 @@ components:
           title: Email
       type: object
       required:
-        - dob
-        - gender
+      - dob
+      - gender
       title: ClientFacingPatientDetailsCompatible
     ClientFacingPayorSearchResponse:
       properties:
         code:
           type: string
           title: Code
-          description: Payor code returned for the insurance information required by Labcorp.
+          description: Payor code returned for the insurance information required
+            by Labcorp.
         name:
           type: string
           title: Name
-          description: Insurance name returned for the insurance information required by Labcorp.
+          description: Insurance name returned for the insurance information required
+            by Labcorp.
         org_address:
           allOf:
-            - $ref: '#/components/schemas/Address'
+          - "$ref": "#/components/schemas/Address"
           title: Org Address
-          description: Insurance business address returned for the insurance information required by Labcorp.
+          description: Insurance business address returned for the insurance information
+            required by Labcorp.
       type: object
       required:
-        - code
-        - name
-        - org_address
+      - code
+      - name
+      - org_address
       title: ClientFacingPayorSearchResponse
     ClientFacingProfile:
       properties:
@@ -6803,7 +5948,9 @@ components:
           type: string
           format: uuid
           title: User Id
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         id:
           type: string
           format: uuid
@@ -6812,57 +5959,154 @@ components:
           type: integer
           title: Height
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingSource"
       type: object
       required:
-        - user_id
-        - id
-        - source
+      - user_id
+      - id
+      - source
       title: ClientFacingProfile
       example:
-        id: 2cdafaca-82b8-466c-95d7-dfcd489eebf9
+        id: 664c477d-57fb-4660-93d4-dccea2e76bd0
         height: 183
         source:
           name: Oura
           slug: oura
           logo: https://logo_url.com
-        user_id: b1328d82-684a-4054-9231-73d0396c2111
+        user_id: 273777d1-9f83-4b0a-b674-7d16f7266b73
+    ClientFacingProvider:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Name of source of information
+        slug:
+          type: string
+          title: Slug
+          description: Slug for designated source
+        logo:
+          type: string
+          title: Logo
+          description: URL for source logo
+      type: object
+      required:
+      - name
+      - slug
+      - logo
+      title: Provider
+      description: A vendor, a service, or a platform which Vital can connect with.
+      example:
+        name: Oura
+        slug: oura
+        logo: https://logo_url.com
+    ClientFacingProviderDetailed:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Name of source of information
+        slug:
+          type: string
+          title: Slug
+          description: Slug for designated source
+        description:
+          type: string
+          title: Description
+          description: Description of source of information
+        logo:
+          type: string
+          title: Logo
+          description: URL for source logo
+        auth_type:
+          "$ref": "#/components/schemas/SourceAuthType"
+        supported_resources:
+          items:
+            "$ref": "#/components/schemas/ClientFacingResource"
+          type: array
+          default: []
+      type: object
+      required:
+      - name
+      - slug
+      - description
+      title: Provider
+      example:
+        name: Oura
+        slug: oura
+        logo: https://logo_url.com
+        auth_type: oauth
+        supported_resources:
+        - workouts
+        - sleep
+    ClientFacingProviderWithStatus:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Name of source of information
+        slug:
+          type: string
+          title: Slug
+          description: Slug for designated source
+        logo:
+          type: string
+          title: Logo
+          description: URL for source logo
+        status:
+          type: string
+          title: Status
+          description: Status of source, either error or connected
+      type: object
+      required:
+      - name
+      - slug
+      - logo
+      - status
+      title: Provider
+      example:
+        name: Oura
+        slug: oura
+        logo: https://logo_url.com
+        status: error
     ClientFacingResource:
       type: string
       enum:
-        - profile
-        - activity
-        - sleep
-        - body
-        - workouts
-        - workout_stream
-        - connection
-        - order
-        - glucose
-        - heartrate
-        - hrv
-        - hypnogram
-        - ige
-        - igg
-        - blood_oxygen
-        - blood_pressure
-        - cholesterol
-        - device
-        - weight
-        - fat
-        - meal
-        - water
-        - caffeine
-        - mindfulness_minutes
-        - steps
-        - calories_active
-        - distance
-        - floors_climbed
-        - respiratory_rate
-        - vo2_max
-        - calories_basal
-        - stress_level
-        - sleep_stream
+      - profile
+      - activity
+      - sleep
+      - body
+      - workouts
+      - workout_stream
+      - connection
+      - order
+      - result
+      - appointment
+      - glucose
+      - heartrate
+      - hrv
+      - hypnogram
+      - ige
+      - igg
+      - blood_oxygen
+      - blood_pressure
+      - cholesterol
+      - device
+      - weight
+      - fat
+      - meal
+      - water
+      - caffeine
+      - mindfulness_minutes
+      - steps
+      - calories_active
+      - distance
+      - floors_climbed
+      - respiratory_rate
+      - vo2_max
+      - calories_basal
+      - stress_level
+      - electrocardiogram_voltage
+      - sleep_stream
       title: ClientFacingResource
       description: An enumeration.
     ClientFacingRespiratoryRateTimeseries:
@@ -6870,38 +6114,40 @@ components:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in bpm.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: Average respiratory rate::breaths per minute
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in bpm.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingRespiratoryRateTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610575+00:00'
+        timestamp: '2023-10-30T18:44:11.467493+00:00'
         value: 15.5
-        type: automatic
         unit: bpm
     ClientFacingShipment:
       properties:
@@ -6940,28 +6186,30 @@ components:
           description: Notes associated to the Vital shipment
       type: object
       required:
-        - id
+      - id
       title: ClientFacingShipment
       description: |-
         Schema for a Shipment in the client facing API.
 
         To be used as part of a ClientFacingTestkitOrder.
       example:
-        id: 62185e12-1073-44d1-ac8b-b7cd7b14777f
-        outbound_tracking_number: <outbound_tracking_number>
-        outbound_tracking_url: <outbound_tracking_url>
-        inbound_tracking_number: <inbound_tracking_number>
-        inbound_tracking_url: <inbound_tracking_url>
+        id: 42b213ce-71fd-4a21-a0bc-7f89c3675e60
+        outbound_tracking_number: "<outbound_tracking_number>"
+        outbound_tracking_url: "<outbound_tracking_url>"
+        inbound_tracking_number: "<inbound_tracking_number>"
+        inbound_tracking_url: "<inbound_tracking_url>"
         outbound_courier: usps
         inbound_courier: usps
-        notes: <notes>
+        notes: "<notes>"
     ClientFacingSleep:
       properties:
         user_id:
           type: string
           format: uuid
           title: User Id
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         id:
           type: string
           format: uuid
@@ -6970,13 +6218,15 @@ components:
           type: string
           format: date-time
           title: Date
-          description: Date of the specified record, formatted as ISO8601 datetime string in UTC 00:00. Deprecated in favour of calendar_date.
+          description: Date of the specified record, formatted as ISO8601 datetime
+            string in UTC 00:00. Deprecated in favour of calendar_date.
           deprecated: true
         calendar_date:
           type: string
           format: date
           title: Calendar Date
-          description: Date of the sleep summary in the YYYY-mm-dd format. This generally matches the sleep end date.
+          description: Date of the sleep summary in the YYYY-mm-dd format. This generally
+            matches the sleep end date.
         bedtime_start:
           type: string
           format: date-time
@@ -6990,15 +6240,19 @@ components:
         timezone_offset:
           type: integer
           title: Timezone Offset
-          description: Timezone offset from UTC as seconds. For example, EEST (Eastern European Summer Time, +3h) is 10800. PST (Pacific Standard Time, -8h) is -28800::seconds
+          description: Timezone offset from UTC as seconds. For example, EEST (Eastern
+            European Summer Time, +3h) is 10800. PST (Pacific Standard Time, -8h)
+            is -28800::seconds
         duration:
           type: integer
           title: Duration
-          description: Total duration of the sleep period (sleep.duration = sleep.bedtime_end - sleep.bedtime_start)::seconds
+          description: Total duration of the sleep period (sleep.duration = sleep.bedtime_end
+            - sleep.bedtime_start)::seconds
         total:
           type: integer
           title: Total
-          description: Total amount of sleep registered during the sleep period (sleep.total = sleep.rem + sleep.light + sleep.deep)::seconds
+          description: Total amount of sleep registered during the sleep period (sleep.total
+            = sleep.rem + sleep.light + sleep.deep)::seconds
         awake:
           type: integer
           title: Awake
@@ -7010,31 +6264,38 @@ components:
         rem:
           type: integer
           title: Rem
-          description: Total amount of REM sleep registered during the sleep period, minutes::seconds
+          description: Total amount of REM sleep registered during the sleep period,
+            minutes::seconds
         deep:
           type: integer
           title: Deep
-          description: Total amount of deep (N3) sleep registered during the sleep period::seconds
+          description: Total amount of deep (N3) sleep registered during the sleep
+            period::seconds
         score:
           type: integer
           title: Score
-          description: A value between 1 and 100 representing how well the user slept. Currently only available for Withings, Oura, Whoop and Garmin::scalar
+          description: A value between 1 and 100 representing how well the user slept.
+            Currently only available for Withings, Oura, Whoop and Garmin::scalar
         hr_lowest:
           type: integer
           title: Hr Lowest
-          description: The lowest heart rate (5 minutes sliding average) registered during the sleep period::beats per minute
+          description: The lowest heart rate (5 minutes sliding average) registered
+            during the sleep period::beats per minute
         hr_average:
           type: integer
           title: Hr Average
-          description: The average heart rate registered during the sleep period::beats per minute
+          description: The average heart rate registered during the sleep period::beats
+            per minute
         efficiency:
           type: number
           title: Efficiency
-          description: Sleep efficiency is the percentage of the sleep period spent asleep (100% * sleep.total / sleep.duration)::perc
+          description: Sleep efficiency is the percentage of the sleep period spent
+            asleep (100% * sleep.total / sleep.duration)::perc
         latency:
           type: integer
           title: Latency
-          description: Detected latency from bedtime_start to the beginning of the first five minutes of persistent sleep::seconds
+          description: Detected latency from bedtime_start to the beginning of the
+            first five minutes of persistent sleep::seconds
         temperature_delta:
           type: number
           title: Temperature Delta
@@ -7043,43 +6304,51 @@ components:
           type: number
           title: Skin Temperature
           description: The skin temperature::celcius
+        hr_dip:
+          type: number
+          title: Hr Dip
+          description: Sleeping Heart Rate Dip is the percentage difference between
+            your average waking heart rate and your average sleeping heart rate. In
+            health studies, a greater "dip" is typically seen as a positive indicator
+            of overall health::perc
         average_hrv:
           type: number
           title: Average Hrv
-          description: The average heart rate variability registered during the sleep period::rmssd
+          description: The average heart rate variability registered during the sleep
+            period::rmssd
         respiratory_rate:
           type: number
           title: Respiratory Rate
           description: Average respiratory rate::breaths per minute
         source:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingSource'
+          - "$ref": "#/components/schemas/ClientFacingSource"
           title: Source
           description: Source the data has come from.
         sleep_stream:
-          $ref: '#/components/schemas/ClientFacingSleepStream'
+          "$ref": "#/components/schemas/ClientFacingSleepStream"
       type: object
       required:
-        - user_id
-        - id
-        - date
-        - calendar_date
-        - bedtime_start
-        - bedtime_stop
-        - duration
-        - total
-        - awake
-        - light
-        - rem
-        - deep
-        - source
+      - user_id
+      - id
+      - date
+      - calendar_date
+      - bedtime_start
+      - bedtime_stop
+      - duration
+      - total
+      - awake
+      - light
+      - rem
+      - deep
+      - source
       title: Sleep Data
       example:
-        id: 0a7db862-b214-409b-a654-12320df6556a
-        date: '2023-08-28T19:42:39.677732+00:00'
-        calendar_date: '2023-08-28'
-        bedtime_start: '2023-08-28T19:42:39.677824+00:00'
-        bedtime_stop: '2023-08-28T19:42:39.677844+00:00'
+        id: 7d0b8f18-3e6c-4f5e-b3ac-85aa3538d378
+        date: '2023-10-30T18:44:12+00:00'
+        calendar_date: '2023-10-30'
+        bedtime_start: '2023-10-30T18:44:12+00:00'
+        bedtime_stop: '2023-10-30T18:44:12+00:00'
         timezone_offset: 2400
         duration: 28800
         total: 28800
@@ -7096,33 +6365,32 @@ components:
         average_hrv: 78
         respiratory_rate: 14
         source:
-          name: Oura
-          slug: oura
-          logo: https://logo_url.com
-        user_id: 65120117-9bc5-43fb-8f20-fca023ecf7e8
+          provider: oura
+          type: unknown
+        user_id: 65e1e0e5-521a-47ea-ba0f-102bbb1ebd5a
     ClientFacingSleepStream:
       properties:
         hrv:
           items:
-            $ref: '#/components/schemas/ClientFacingHRVTimeseries'
+            "$ref": "#/components/schemas/ClientFacingHRVTimeseries"
           type: array
           title: Hrv
           default: []
         heartrate:
           items:
-            $ref: '#/components/schemas/ClientFacingHeartRateTimeseries'
+            "$ref": "#/components/schemas/ClientFacingHeartRateTimeseries"
           type: array
           title: Heartrate
           default: []
         hypnogram:
           items:
-            $ref: '#/components/schemas/ClientFacingHypnogramTimeseries'
+            "$ref": "#/components/schemas/ClientFacingHypnogramTimeseries"
           type: array
           title: Hypnogram
           default: []
         respiratory_rate:
           items:
-            $ref: '#/components/schemas/ClientFacingRespiratoryRateTimeseries'
+            "$ref": "#/components/schemas/ClientFacingRespiratoryRateTimeseries"
           type: array
           title: Respiratory Rate
           default: []
@@ -7130,202 +6398,136 @@ components:
       title: Sleep stream data
       example:
         hrv:
-          - id: 0
-            timestamp: '2023-08-28T19:42:39.674565+00:00'
-            value: 72
-            type: automatic
-            unit: rmssd
-          - id: 1
-            timestamp: '2023-08-28T19:43:09.674727+00:00'
-            value: 40
-            type: automatic
-            unit: rmssd
-          - id: 2
-            timestamp: '2023-08-28T19:43:39.674816+00:00'
-            value: 14
-            type: automatic
-            unit: rmssd
-          - id: 3
-            timestamp: '2023-08-28T19:44:09.674897+00:00'
-            value: 30
-            type: automatic
-            unit: rmssd
-          - id: 4
-            timestamp: '2023-08-28T19:44:39.674984+00:00'
-            value: 15
-            type: automatic
-            unit: rmssd
+        - id: 0
+          timestamp: '2023-10-30T18:44:12.499169+00:00'
+          value: 23
+          unit: rmssd
+        - id: 1
+          timestamp: '2023-10-30T18:44:42.499301+00:00'
+          value: 20
+          unit: rmssd
+        - id: 2
+          timestamp: '2023-10-30T18:45:12.499358+00:00'
+          value: 62
+          unit: rmssd
+        - id: 3
+          timestamp: '2023-10-30T18:45:42.499447+00:00'
+          value: 60
+          unit: rmssd
+        - id: 4
+          timestamp: '2023-10-30T18:46:12.499492+00:00'
+          value: 84
+          unit: rmssd
         heartrate:
-          - id: 0
-            timestamp: '2023-08-28T19:42:39.675063+00:00'
-            value: 20
-            type: automatic
-            unit: bpm
-          - id: 1
-            timestamp: '2023-08-28T19:43:09.675129+00:00'
-            value: 93
-            type: automatic
-            unit: bpm
-          - id: 2
-            timestamp: '2023-08-28T19:43:39.675191+00:00'
-            value: 135
-            type: automatic
-            unit: bpm
-          - id: 3
-            timestamp: '2023-08-28T19:44:09.675273+00:00'
-            value: 81
-            type: automatic
-            unit: bpm
-          - id: 4
-            timestamp: '2023-08-28T19:44:39.675336+00:00'
-            value: 189
-            type: automatic
-            unit: bpm
+        - id: 0
+          timestamp: '2023-10-30T18:44:12.499533+00:00'
+          value: 26
+          unit: bpm
+        - id: 1
+          timestamp: '2023-10-30T18:44:42.499571+00:00'
+          value: 64
+          unit: bpm
+        - id: 2
+          timestamp: '2023-10-30T18:45:12.499605+00:00'
+          value: 147
+          unit: bpm
+        - id: 3
+          timestamp: '2023-10-30T18:45:42.499663+00:00'
+          value: 174
+          unit: bpm
+        - id: 4
+          timestamp: '2023-10-30T18:46:12.499709+00:00'
+          value: 99
+          unit: bpm
         hypnogram:
-          - id: 0
-            timestamp: '2023-08-28T19:42:39.675399+00:00'
-            value: -1
-            type: automatic
-            unit: stage
-          - id: 1
-            timestamp: '2023-08-28T19:43:09.675455+00:00'
-            value: 0
-            type: automatic
-            unit: stage
-          - id: 2
-            timestamp: '2023-08-28T19:43:39.675504+00:00'
-            value: 3
-            type: automatic
-            unit: stage
-          - id: 3
-            timestamp: '2023-08-28T19:44:09.675558+00:00'
-            value: 0
-            type: automatic
-            unit: stage
-          - id: 4
-            timestamp: '2023-08-28T19:44:39.675614+00:00'
-            value: 3
-            type: automatic
-            unit: stage
+        - id: 0
+          timestamp: '2023-10-30T18:44:12.499750+00:00'
+          value: 0
+          unit: stage
+        - id: 1
+          timestamp: '2023-10-30T18:44:42.499785+00:00'
+          value: -1
+          unit: stage
+        - id: 2
+          timestamp: '2023-10-30T18:45:12.499816+00:00'
+          value: 2
+          unit: stage
+        - id: 3
+          timestamp: '2023-10-30T18:45:42.499851+00:00'
+          value: 1
+          unit: stage
+        - id: 4
+          timestamp: '2023-10-30T18:46:12.499883+00:00'
+          value: 0
+          unit: stage
         respiratory_rate:
-          - id: 0
-            timestamp: '2023-08-28T19:42:39.675684+00:00'
-            value: 27
-            type: automatic
-            unit: bpm
-          - id: 1
-            timestamp: '2023-08-28T19:43:09.675739+00:00'
-            value: 10
-            type: automatic
-            unit: bpm
-          - id: 2
-            timestamp: '2023-08-28T19:43:39.675794+00:00'
-            value: 15
-            type: automatic
-            unit: bpm
-          - id: 3
-            timestamp: '2023-08-28T19:44:09.675849+00:00'
-            value: 12
-            type: automatic
-            unit: bpm
-          - id: 4
-            timestamp: '2023-08-28T19:44:39.675904+00:00'
-            value: 22
-            type: automatic
-            unit: bpm
+        - id: 0
+          timestamp: '2023-10-30T18:44:12.499916+00:00'
+          value: 26
+          unit: bpm
+        - id: 1
+          timestamp: '2023-10-30T18:44:42.499946+00:00'
+          value: 11
+          unit: bpm
+        - id: 2
+          timestamp: '2023-10-30T18:45:12.499974+00:00'
+          value: 22
+          unit: bpm
+        - id: 3
+          timestamp: '2023-10-30T18:45:42.500005+00:00'
+          value: 16
+          unit: bpm
+        - id: 4
+          timestamp: '2023-10-30T18:46:12.500036+00:00'
+          value: 17
+          unit: bpm
     ClientFacingSource:
       properties:
+        provider:
+          type: string
+          title: Provider
+          description: Provider slug. e.g., `oura`, `fitbit`, `garmin`.
+        type:
+          type: string
+          title: Type
+          description: The type of the data source (app or device) by which the summary
+            or the timeseries data were recorded. This defaults to `unknown` when
+            Vital cannot extract or infer that information
+          default: unknown
+        app_id:
+          type: string
+          title: App Id
+          description: The identifier of the app which recorded this summary. This
+            is only applicable to multi-source providers like Apple Health and Android
+            Health Connect.
         name:
           type: string
           title: Name
-          description: Name of source of information
+          description: Deprecated. Subject to removal after 1 Jan 2024.
+          deprecated: true
         slug:
           type: string
           title: Slug
-          description: Slug for designated source
+          description: Deprecated. Use `provider` instead. Subject to removal after
+            1 Jan 2024.
+          deprecated: true
         logo:
           type: string
           title: Logo
-          description: URL for source logo
+          description: Deprecated. Subject to removal after 1 Jan 2024.
+          deprecated: true
       type: object
       required:
-        - name
-        - slug
-        - logo
-      title: Provider
+      - provider
+      - name
+      - slug
+      - logo
+      title: Source
+      description: |-
+        Source summarizes where a sample or a summary is sourced from.
+        At minimum, the source provider is always included.
       example:
-        name: Oura
-        slug: oura
-        logo: https://logo_url.com
-    ClientFacingSourceDetailed:
-      properties:
-        name:
-          type: string
-          title: Name
-          description: Name of source of information
-        slug:
-          type: string
-          title: Slug
-          description: Slug for designated source
-        description:
-          type: string
-          title: Description
-          description: Description of source of information
-        logo:
-          type: string
-          title: Logo
-          description: URL for source logo
-        auth_type:
-          $ref: '#/components/schemas/SourceAuthType'
-        supported_resources:
-          items:
-            $ref: '#/components/schemas/ClientFacingResource'
-          type: array
-          default: []
-      type: object
-      required:
-        - name
-        - slug
-        - description
-      title: Provider
-      example:
-        name: Oura
-        slug: oura
-        logo: https://logo_url.com
-        auth_type: oauth
-        supported_resources:
-          - workouts
-          - sleep
-    ClientFacingSourceWithStatus:
-      properties:
-        name:
-          type: string
-          title: Name
-          description: Name of source of information
-        slug:
-          type: string
-          title: Slug
-          description: Slug for designated source
-        logo:
-          type: string
-          title: Logo
-          description: URL for source logo
-        status:
-          type: string
-          title: Status
-          description: Status of source, either error or connected
-      type: object
-      required:
-        - name
-        - slug
-        - logo
-        - status
-      title: Provider
-      example:
-        name: Oura
-        slug: oura
-        logo: https://logo_url.com
-        status: error
+        provider: oura
     ClientFacingSport:
       properties:
         id:
@@ -7341,60 +6543,76 @@ components:
           description: Slug for designated sport
       type: object
       required:
-        - id
-        - name
-        - slug
+      - id
+      - name
+      - slug
       title: ClientFacingSport
     ClientFacingStepsTimeseries:
       properties:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          enum:
+          - count
+          title: Unit
+          description: Measured in counts
         timestamp:
           type: string
           format: date-time
           title: Timestamp
-          description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
+          description: Depracated. The start time (inclusive) of the interval.
+        start:
+          type: string
+          format: date-time
+          title: Start
+          description: The start time (inclusive) of the interval.
+        end:
+          type: string
+          format: date-time
+          title: End
+          description: The end time (exclusive) of the interval.
         value:
           type: number
           title: Value
           description: The number of steps sampled at the time or interval::count
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          enum:
-            - count
-          title: Unit
-          description: Measured in counts
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - start
+      - end
+      - value
       title: ClientFacingStepsTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610510+00:00'
+        timestamp: '2023-10-30T18:44:11.465936+00:00'
+        start: '2023-10-30T18:44:11.466069+00:00'
+        end: '2023-10-30T18:49:11.466166+00:00'
         value: 123
-        type: automatic
         unit: count
     ClientFacingStream:
       properties:
         cadence:
           anyOf:
-            - items:
-                type: number
-              type: array
-            - items:
-                type: number
-              type: array
+          - items:
+              type: number
+            type: array
+          - items:
+              type: number
+            type: array
           title: Cadence
           description: RPM for cycling, Steps per minute for running
           default: []
@@ -7407,89 +6625,89 @@ components:
           default: []
         altitude:
           anyOf:
-            - items:
-                type: number
-              type: array
-            - items:
-                type: number
-              type: array
+          - items:
+              type: number
+            type: array
+          - items:
+              type: number
+            type: array
           title: Altitude
           description: Data points for altitude
           default: []
         velocity_smooth:
           anyOf:
-            - items:
-                type: number
-              type: array
-            - items:
-                type: number
-              type: array
+          - items:
+              type: number
+            type: array
+          - items:
+              type: number
+            type: array
           title: Velocity Smooth
           description: Velocity in m/s
           default: []
         heartrate:
           anyOf:
-            - items:
-                type: integer
-              type: array
-            - items:
-                type: integer
-              type: array
+          - items:
+              type: integer
+            type: array
+          - items:
+              type: integer
+            type: array
           title: Heartrate
           description: Heart rate in bpm
           default: []
         lat:
           anyOf:
-            - items:
-                type: number
-              type: array
-            - items:
-                type: number
-              type: array
+          - items:
+              type: number
+            type: array
+          - items:
+              type: number
+            type: array
           title: Lat
           description: Latitude for data point
           default: []
         lng:
           anyOf:
-            - items:
-                type: number
-              type: array
-            - items:
-                type: number
-              type: array
+          - items:
+              type: number
+            type: array
+          - items:
+              type: number
+            type: array
           title: Lng
           description: Longitude for data point
           default: []
         distance:
           anyOf:
-            - items:
-                type: number
-              type: array
-            - items:
-                type: number
-              type: array
+          - items:
+              type: number
+            type: array
+          - items:
+              type: number
+            type: array
           title: Distance
           description: Cumulated distance for exercise
           default: []
         power:
           anyOf:
-            - items:
-                type: number
-              type: array
-            - items:
-                type: number
-              type: array
+          - items:
+              type: number
+            type: array
+          - items:
+              type: number
+            type: array
           title: Power
           description: Power in watts
           default: []
         resistance:
           anyOf:
-            - items:
-                type: number
-              type: array
-            - items:
-                type: number
-              type: array
+          - items:
+              type: number
+            type: array
+          - items:
+              type: number
+            type: array
           title: Resistance
           description: Resistance on bike
           default: []
@@ -7497,65 +6715,65 @@ components:
       title: ClientFacingStream
       example:
         cadence:
-          - 10
-          - 12
-          - 12
-          - 11
-          - 10
+        - 10
+        - 12
+        - 12
+        - 11
+        - 10
         time:
-          - 1626625123
-          - 1626625140
-          - 1626625145
-          - 1626625150
-          - 162662560
+        - 1626625123
+        - 1626625140
+        - 1626625145
+        - 1626625150
+        - 162662560
         heartrate:
-          - 120
-          - 125
-          - 125
-          - 130
-          - 135
+        - 120
+        - 125
+        - 125
+        - 130
+        - 135
         distance:
-          - 12
-          - 15
-          - 18
-          - 20
-          - 25
+        - 12
+        - 15
+        - 18
+        - 20
+        - 25
         power:
-          - 100
-          - 100
-          - 100
-          - 100
-          - 100
+        - 100
+        - 100
+        - 100
+        - 100
+        - 100
         altitude:
-          - 10
-          - 20
-          - 30
-          - 40
-          - 50
+        - 10
+        - 20
+        - 30
+        - 40
+        - 50
         velocity_smooth:
-          - 10
-          - 20
-          - 30
-          - 40
-          - 50
+        - 10
+        - 20
+        - 30
+        - 40
+        - 50
         lat:
-          - 10
-          - 20
-          - 30
-          - 40
-          - 50
+        - 10
+        - 20
+        - 30
+        - 40
+        - 50
         lng:
-          - 10
-          - 20
-          - 30
-          - 40
-          - 50
+        - 10
+        - 20
+        - 30
+        - 40
+        - 50
         resistance:
-          - 10
-          - 20
-          - 30
-          - 40
-          - 50
+        - 10
+        - 20
+        - 30
+        - 40
+        - 50
     ClientFacingTeam:
       properties:
         id:
@@ -7588,23 +6806,17 @@ components:
           type: string
           title: Webhook Secret
           default: ''
-        connected_sources:
-          items:
-            $ref: '#/components/schemas/ConnectedSourceClientFacingRedacted'
-          type: array
-          title: Connected Sources
-          default: []
         api_key:
           type: string
           title: Api Key
           default: ''
         api_keys:
           items:
-            $ref: '#/components/schemas/ClientFacingApiKey'
+            "$ref": "#/components/schemas/ClientFacingApiKey"
           type: array
           title: Api Keys
         configuration:
-          $ref: '#/components/schemas/TeamConfig'
+          "$ref": "#/components/schemas/TeamConfig"
         testkits_texts_enabled:
           type: boolean
           title: Testkits Texts Enabled
@@ -7612,28 +6824,36 @@ components:
         lab_tests_patient_communication_enabled:
           type: boolean
           title: Lab Tests Patient Communication Enabled
+        lab_tests_patient_sms_communication_enabled:
+          type: boolean
+          title: Lab Tests Patient Sms Communication Enabled
+        lab_tests_patient_email_communication_enabled:
+          type: boolean
+          title: Lab Tests Patient Email Communication Enabled
         logo_url:
           type: string
           title: Logo Url
       type: object
       required:
-        - id
-        - name
-        - testkits_texts_enabled
-        - lab_tests_patient_communication_enabled
+      - id
+      - name
+      - testkits_texts_enabled
+      - lab_tests_patient_communication_enabled
+      - lab_tests_patient_sms_communication_enabled
+      - lab_tests_patient_email_communication_enabled
       title: ClientFacingTeam
     ClientFacingTestKitOrderDetails:
       properties:
         type:
           type: string
           enum:
-            - testkit
+          - testkit
           title: Type
         data:
-          $ref: '#/components/schemas/ClientFacingTestkitOrder'
+          "$ref": "#/components/schemas/ClientFacingTestkitOrder"
       type: object
       required:
-        - type
+      - type
       title: ClientFacingTestKitOrderDetails
     ClientFacingTestkitOrder:
       properties:
@@ -7644,7 +6864,7 @@ components:
           description: The Vital TestKit Order ID
         shipment:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingShipment'
+          - "$ref": "#/components/schemas/ClientFacingShipment"
           title: Shipment
           description: Shipment object
         created_at:
@@ -7657,25 +6877,25 @@ components:
           title: Updated At
       type: object
       required:
-        - id
-        - created_at
-        - updated_at
+      - id
+      - created_at
+      - updated_at
       title: ClientFacingTestkitOrder
       description: |-
         Schema for a testkit order in the client facing API.
 
         To be used as part of a ClientFacingOrder.
       example:
-        id: 3914a77e-5ada-43e9-92cc-5debcfb862f9
+        id: e10566d9-64fb-443a-8130-f556c8812402
         shipment:
-          id: 7913d8f8-15af-40fb-895b-e4cd6d1cd20d
-          outbound_tracking_number: <outbound_tracking_number>
-          outbound_tracking_url: <outbound_tracking_url>
-          inbound_tracking_number: <inbound_tracking_number>
-          inbound_tracking_url: <inbound_tracking_url>
+          id: a235bf71-70ee-411e-b0cf-d8d6ab66a4e7
+          outbound_tracking_number: "<outbound_tracking_number>"
+          outbound_tracking_url: "<outbound_tracking_url>"
+          inbound_tracking_number: "<inbound_tracking_number>"
+          inbound_tracking_url: "<inbound_tracking_url>"
           outbound_courier: usps
           inbound_courier: usps
-          notes: <notes>
+          notes: "<notes>"
           created_at: '2020-01-01T00:00:00.000Z'
           updated_at: '2020-01-01T00:00:00.000Z'
         created_at: '2020-01-01T00:00:00Z'
@@ -7686,7 +6906,9 @@ components:
           type: string
           format: uuid
           title: User Id
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         team_id:
           type: string
           format: uuid
@@ -7695,7 +6917,9 @@ components:
         client_user_id:
           type: string
           title: Client User Id
-          description: A unique ID representing the end user. Typically this will be a user ID from your application. Personally identifiable information, such as an email address or phone number, should not be used in the client_user_id.
+          description: A unique ID representing the end user. Typically this will
+            be a user ID from your application. Personally identifiable information,
+            such as an email address or phone number, should not be used in the client_user_id.
         created_on:
           type: string
           format: date-time
@@ -7703,72 +6927,77 @@ components:
           description: When your item is created
         connected_sources:
           items:
-            $ref: '#/components/schemas/ConnectedSourceClientFacing'
+            "$ref": "#/components/schemas/ConnectedSourceClientFacing"
           type: array
           title: Connected Sources
           description: A list of the users connected sources.
         fallback_time_zone:
           allOf:
-            - $ref: '#/components/schemas/FallbackTimeZone'
+          - "$ref": "#/components/schemas/FallbackTimeZone"
           title: Fallback Time Zone
-          description: |2-
-
-                Fallback time zone of the user, in the form of a valid IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).
-                Used when pulling data from sources that are completely time zone agnostic (e.g., all time is relative to UTC clock, without any time zone attributions on data points).
-                
+          description: "\n    Fallback time zone of the user, in the form of a valid
+            IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).\n
+            \   Used when pulling data from sources that are completely time zone
+            agnostic (e.g., all time is relative to UTC clock, without any time zone
+            attributions on data points).\n    "
       type: object
       required:
-        - user_id
-        - team_id
-        - client_user_id
-        - created_on
-        - connected_sources
+      - user_id
+      - team_id
+      - client_user_id
+      - created_on
+      - connected_sources
       title: User
       example:
-        user_id: 22add9b9-cc59-418c-8652-73e89e6e2e43
-        team_id: 725d4243-b514-4a28-be4f-5d9f5bd31119
-        client_user_id: 43e9e065-acfe-4d1d-8bed-8c08ebdc11e0
+        user_id: 4192d53d-399a-450b-ad14-d7f17a70db05
+        team_id: a2dc218b-1dc2-48a5-8c70-f13692141a3d
+        client_user_id: 0e02f0db-f241-44c9-a445-fa36964fabc1
+        created_on: '2023-10-30T18:44:09+00:00'
         connected_sources:
-          - source:
-              name: Oura
-              slug: oura
-              logo: logo_url
-            created_on: '2023-08-28T19:42:32.574313+00:00'
+        - source:
+            name: Oura
+            slug: oura
+            logo: logo_url
+          created_on: '2023-10-30T18:44:09+00:00'
         fallback_time_zone:
           id: Europe/London
           source_slug: manual
-          updated_at: '2023-08-28T19:42:32.574361+00:00'
+          updated_at: '2023-10-30T18:44:09+00:00'
     ClientFacingUserKey:
       properties:
         user_id:
           type: string
           format: uuid
           title: User Id
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         client_user_id:
           type: string
           title: Client User Id
-          description: A unique ID representing the end user. Typically this will be a user ID from your application. Personally identifiable information, such as an email address or phone number, should not be used in the client_user_id.
+          description: A unique ID representing the end user. Typically this will
+            be a user ID from your application. Personally identifiable information,
+            such as an email address or phone number, should not be used in the client_user_id.
       type: object
       required:
-        - user_id
-        - client_user_id
+      - user_id
+      - client_user_id
       title: ClientFacingUserKey
       example:
-        client_user_id: 7e296ff9-7e9f-491f-9f8c-70da940fc3cf
-        user_id: 2579bf6f-8358-4baa-afb5-d9ae3de07486
+        client_user_id: 3e8d43aa-70be-4503-8f54-292b9823915d
+        user_id: bcfa811e-7f30-4eb3-97b5-e6416c84cd62
     ClientFacingWalkInOrderDetails:
       properties:
         type:
           type: string
           enum:
-            - walk_in_test
+          - walk_in_test
           title: Type
         data:
-          $ref: '#/components/schemas/ClientFacingWalkInTestOrder'
+          "$ref": "#/components/schemas/ClientFacingWalkInTestOrder"
       type: object
       required:
-        - type
+      - type
       title: ClientFacingWalkInOrderDetails
     ClientFacingWalkInTestOrder:
       properties:
@@ -7787,16 +7016,16 @@ components:
           title: Updated At
       type: object
       required:
-        - id
-        - created_at
-        - updated_at
+      - id
+      - created_at
+      - updated_at
       title: ClientFacingWalkInTestOrder
       description: |-
         Schema for a walk-in test order in the client facing API.
 
         To be used as part of a ClientFacingOrder.
       example:
-        id: c3133079-93d2-447d-a3ad-7021168023c3
+        id: f19cb46f-d975-4a2f-85a3-f5cf3cd98a57
         created_at: '2020-01-01T00:00:00Z'
         updated_at: '2020-01-01T00:00:00Z'
     ClientFacingWaterTimeseries:
@@ -7804,38 +7033,40 @@ components:
         id:
           type: integer
           title: Id
-          description: Measurement id. Note, this field has been deprecated and is no longer used
+          description: Deprecated
+        timezone_offset:
+          type: integer
+          title: Timezone Offset
+          description: Time zone UTC offset in seconds. Positive offset indicates
+            east of UTC; negative offset indicates west of UTC; and null indicates
+            the time zone information is unavailable at source.
+        type:
+          type: string
+          title: Type
+          description: The reading type of the measurement. This is applicable only
+            to Cholesterol, IGG and IGE.
+        unit:
+          type: string
+          title: Unit
+          description: Measured in milliters.
         timestamp:
           type: string
           format: date-time
           title: Timestamp
           description: The timestamp of the measurement.
-        timezone_offset:
-          type: integer
-          title: Timezone Offset
-          description: Time zone UTC offset of the measurement. Positive offset indicates east of UTC; negative offset indicates west of UTC; and null indicates the time zone information is unavailable at source.
         value:
           type: number
           title: Value
           description: Quantity of water drank during the time period.
-        type:
-          type: string
-          title: Type
-          description: The reading type of the measurement, e.g. cuff, scale, manual_scan, etc.
-        unit:
-          type: string
-          title: Unit
-          description: Measured in milliters.
       type: object
       required:
-        - timestamp
-        - value
-        - unit
+      - unit
+      - timestamp
+      - value
       title: ClientFacingWaterTimeseries
       example:
-        timestamp: '2023-08-28T19:42:37.610473+00:00'
+        timestamp: '2023-10-30T18:44:11.465291+00:00'
         value: 400
-        type: automatic
         unit: ml
     ClientFacingWorkout:
       properties:
@@ -7843,7 +7074,9 @@ components:
           type: string
           format: uuid
           title: User Id
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         id:
           type: string
           format: uuid
@@ -7855,7 +7088,9 @@ components:
         timezone_offset:
           type: integer
           title: Timezone Offset
-          description: Timezone offset from UTC as seconds. For example, EEST (Eastern European Summer Time, +3h) is 10800. PST (Pacific Standard Time, -8h) is -28800::seconds
+          description: Timezone offset from UTC as seconds. For example, EEST (Eastern
+            European Summer Time, +3h) is 10800. PST (Pacific Standard Time, -8h)
+            is -28800::seconds
         average_hr:
           type: integer
           title: Average Hr
@@ -7872,7 +7107,8 @@ components:
           type: string
           format: date
           title: Calendar Date
-          description: Date of the workout summary in the YYYY-mm-dd format. This generally matches the workout start date.
+          description: Date of the workout summary in the YYYY-mm-dd format. This
+            generally matches the workout start date.
         time_start:
           type: string
           format: date-time
@@ -7889,7 +7125,7 @@ components:
           description: Calories burned during the workout::kCal
         sport:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingSport'
+          - "$ref": "#/components/schemas/ClientFacingSport"
           title: Sport
           description: Sport's name
           default: ''
@@ -7898,7 +7134,10 @@ components:
             type: integer
           type: array
           title: Hr Zones
-          description: Time in seconds spent in different heart rate zones <50%, 50-60%, 60-70%, 70-80%, 80-90%, 90%+. Due to rounding errors, it's possible that summing all values is different than the total time of the workout. Not available for all providers::seconds
+          description: Time in seconds spent in different heart rate zones <50%, 50-60%,
+            60-70%, 70-80%, 80-90%, 90%+. Due to rounding errors, it's possible that
+            summing all values is different than the total time of the workout. Not
+            available for all providers::seconds
         moving_time:
           type: integer
           title: Moving Time
@@ -7949,42 +7188,41 @@ components:
           description: Provider ID given for that specific workout
         source:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingSource'
+          - "$ref": "#/components/schemas/ClientFacingSource"
           title: Source
           description: Source the data has come from.
       type: object
       required:
-        - user_id
-        - id
-        - calendar_date
-        - time_start
-        - time_end
-        - provider_id
-        - source
+      - user_id
+      - id
+      - calendar_date
+      - time_start
+      - time_end
+      - provider_id
+      - source
       title: Workout Data
       example:
-        id: e76d41d1-e026-4f79-b34a-40ae26bd0c8a
+        id: '04569e7c-cb1f-4010-b6b8-e7d13e09aa9d'
         average_hr: 100
         max_hr: 190
         distance: 1700
-        calendar_date: 2023-42-
-        time_start: '2023-08-28T18:42:39.754610+00:00'
-        time_end: '2023-08-28T19:42:39.754703+00:00'
+        calendar_date: 2023-44-
+        time_start: '2023-10-30T17:44:12+00:00'
+        time_end: '2023-10-30T18:44:12+00:00'
         calories: 300
         sport:
           id: 1
           name: football
         source:
-          name: Strava
-          slug: strava
-          logo: https://logo_url.com
+          provider: strava
+          type: unknown
         hr_zones:
-          - 100
-          - 90
-          - 10
-          - 10
-          - 200
-        user_id: 9b6b0d5c-992b-4d5b-8b8a-3c488cb6c826
+        - 100
+        - 90
+        - 10
+        - 10
+        - 200
+        user_id: 29f7505b-3e0e-4678-a398-52c4f6aeddac
         moving_time: 100
         total_elevation_gain: 10
         elev_high: 20.2
@@ -8001,122 +7239,110 @@ components:
       properties:
         sleep:
           items:
-            $ref: '#/components/schemas/ClientFacingSleep'
+            "$ref": "#/components/schemas/ClientFacingSleep"
           type: array
           title: Sleep
       type: object
       required:
-        - sleep
+      - sleep
       title: Sleep Data
       example:
         sleep:
-          - id: 4b48c5e9-6640-4b40-a9e4-91465673dc2c
-            date: '2023-08-28T19:42:39.687734+00:00'
-            calendar_date: '2023-08-28'
-            bedtime_start: '2023-08-28T19:42:39.687837+00:00'
-            bedtime_stop: '2023-08-28T19:42:39.687853+00:00'
-            timezone_offset: 2400
-            duration: 28800
-            total: 28800
-            awake: 2400
-            light: 2400
-            rem: 2400
-            deep: 2400
-            hr_lowest: 43
-            hr_average: 50
-            efficiency: 0.97
-            latency: 1000
-            temperature_delta: -0.2
-            skin_temperature: 36.5
-            average_hrv: 78
-            respiratory_rate: 14
-            source:
-              name: Oura
-              slug: oura
-              logo: https://logo_url.com
-            user_id: 354ce10c-066d-41ef-9b06-d7dcac4853be
+        - id: 7d0b8f18-3e6c-4f5e-b3ac-85aa3538d378
+          date: '2023-10-30T18:44:12+00:00'
+          calendar_date: '2023-10-30'
+          bedtime_start: '2023-10-30T18:44:12+00:00'
+          bedtime_stop: '2023-10-30T18:44:12+00:00'
+          timezone_offset: 2400
+          duration: 28800
+          total: 28800
+          awake: 2400
+          light: 2400
+          rem: 2400
+          deep: 2400
+          hr_lowest: 43
+          hr_average: 50
+          efficiency: 0.97
+          latency: 1000
+          temperature_delta: -0.2
+          skin_temperature: 36.5
+          average_hrv: 78
+          respiratory_rate: 14
+          source:
+            provider: oura
+            type: unknown
+          user_id: 65e1e0e5-521a-47ea-ba0f-102bbb1ebd5a
     ClientWorkoutResponse:
       properties:
         workouts:
           items:
-            $ref: '#/components/schemas/ClientFacingWorkout'
+            "$ref": "#/components/schemas/ClientFacingWorkout"
           type: array
           title: Workouts
       type: object
       required:
-        - workouts
+      - workouts
       title: ClientWorkoutResponse
       example:
         workouts:
-          - id: 19eb7083-9da0-488e-ab65-10e5a79240f8
-            average_hr: 100
-            max_hr: 190
-            distance: 1700
-            calendar_date: 2023-42-
-            time_start: '2023-08-28T18:42:39.760064+00:00'
-            time_end: '2023-08-28T19:42:39.760161+00:00'
-            calories: 300
-            sport:
-              id: 1
-              name: football
-            source:
-              name: Strava
-              slug: strava
-              logo: https://logo_url.com
-            hr_zones:
-              - 100
-              - 90
-              - 10
-              - 10
-              - 200
-            user_id: 7af2ae3d-45bb-4e87-be96-a64f4f41ae51
-            moving_time: 100
-            total_elevation_gain: 10
-            elev_high: 20.2
-            elev_low: -10.2
-            average_speed: 4.2
-            max_speed: 7.8
-            timezone_offset: 3600
-            average_watts: 100
-            device_watts: 80
-            max_watts: 200
-            weighted_average_watts: 250
-            title: Workout Data
-            map:
-              summary_polyline: agn~Ftb{uOvr@daBunBjdBkHwiD????
+        - id: '04569e7c-cb1f-4010-b6b8-e7d13e09aa9d'
+          average_hr: 100
+          max_hr: 190
+          distance: 1700
+          calendar_date: 2023-44-
+          time_start: '2023-10-30T17:44:12+00:00'
+          time_end: '2023-10-30T18:44:12+00:00'
+          calories: 300
+          sport:
+            id: 1
+            name: football
+          source:
+            provider: strava
+            type: unknown
+          hr_zones:
+          - 100
+          - 90
+          - 10
+          - 10
+          - 200
+          user_id: 29f7505b-3e0e-4678-a398-52c4f6aeddac
+          moving_time: 100
+          total_elevation_gain: 10
+          elev_high: 20.2
+          elev_low: -10.2
+          average_speed: 4.2
+          max_speed: 7.8
+          average_watts: 100
+          device_watts: 80
+          max_watts: 200
+          weighted_average_watts: 250
+          map:
+            summary_polyline: agn~Ftb{uOvr@daBunBjdBkHwiD????~Ngn@ha@_N~Ql`@
     ConnectedSourceClientFacing:
       properties:
-        source:
+        provider:
           allOf:
-            - $ref: '#/components/schemas/ClientFacingSource'
-          title: Source
-          description: Source the data has come from.
+          - "$ref": "#/components/schemas/ClientFacingProvider"
+          title: Provider
+          description: The provider of this connected source.
         created_on:
           type: string
           format: date-time
           title: Created On
           description: When your item is created
-      type: object
-      required:
-        - source
-        - created_on
-      title: ConnectedSourceClientFacing
-    ConnectedSourceClientFacingRedacted:
-      properties:
-        id:
-          type: string
-          format: uuid
-          title: Id
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
-        provider_id:
-          type: string
-          title: Provider Id
+          allOf:
+          - "$ref": "#/components/schemas/ClientFacingProvider"
+          title: Source
+          description: Deprecated. Use `provider` instead. Subject to removal after
+            1 Jan 2024.
+          deprecated: true
       type: object
       required:
-        - id
-        - source
-      title: ConnectedSourceClientFacingRedacted
+      - provider
+      - created_on
+      - source
+      title: ConnectedSourceClientFacing
     ConnectionStatus:
       properties:
         success:
@@ -8127,14 +7353,14 @@ components:
           title: Redirect Url
       type: object
       required:
-        - success
+      - success
       title: ConnectionStatus
       example:
         success: true
     Consent:
       properties:
         consentType:
-          $ref: '#/components/schemas/ConsentType'
+          "$ref": "#/components/schemas/ConsentType"
         version:
           type: string
           title: Version
@@ -8145,28 +7371,19 @@ components:
           title: Timeofconsent
       type: object
       required:
-        - consentType
+      - consentType
       title: Consent
     ConsentType:
       type: string
       enum:
-        - terms-of-use
-        - telehealth-informed-consent
-        - mobile-terms-and-conditions
-        - notice-of-privacy-practices
-        - privacy-policy
-        - hipaa-authorization
+      - terms-of-use
+      - telehealth-informed-consent
+      - mobile-terms-and-conditions
+      - notice-of-privacy-practices
+      - privacy-policy
+      - hipaa-authorization
       title: ConsentType
       description: An enumeration.
-    CreateApiKeyBody:
-      properties:
-        label:
-          type: string
-          title: Label
-      type: object
-      required:
-        - label
-      title: CreateApiKeyBody
     CreateLabTestRequest:
       properties:
         marker_ids:
@@ -8181,9 +7398,9 @@ components:
           type: string
           title: Name
         method:
-          $ref: '#/components/schemas/LabTestCollectionMethod'
+          "$ref": "#/components/schemas/LabTestCollectionMethod"
         sample_type:
-          $ref: '#/components/schemas/LabTestSampleType'
+          "$ref": "#/components/schemas/LabTestSampleType"
         description:
           type: string
           title: Description
@@ -8193,12 +7410,12 @@ components:
           default: false
       type: object
       required:
-        - marker_ids
-        - lab_id
-        - name
-        - method
-        - sample_type
-        - description
+      - marker_ids
+      - lab_id
+      - name
+      - method
+      - sample_type
+      - description
       title: CreateLabTestRequest
     CreateOrderRequestCompatible:
       properties:
@@ -8211,29 +7428,30 @@ components:
           format: uuid
           title: Lab Test Id
         physician:
-          $ref: '#/components/schemas/PhysicianCreateRequest'
+          "$ref": "#/components/schemas/PhysicianCreateRequest"
         health_insurance:
-          $ref: '#/components/schemas/HealthInsuranceCreateRequest'
+          "$ref": "#/components/schemas/HealthInsuranceCreateRequest"
         priority:
           type: boolean
           title: Priority
-          description: Defines whether order is priority or not. Only available for Labcorp. For Labcorp, this corresponds to a STAT order.
+          description: Defines whether order is priority or not. Only available for
+            Labcorp. For Labcorp, this corresponds to a STAT order.
           default: false
         consents:
           items:
-            $ref: '#/components/schemas/Consent'
+            "$ref": "#/components/schemas/Consent"
           type: array
           title: Consents
         patient_details:
-          $ref: '#/components/schemas/PatientDetailsCompatible'
+          "$ref": "#/components/schemas/PatientDetails"
         patient_address:
-          $ref: '#/components/schemas/PatientAddressCompatible'
+          "$ref": "#/components/schemas/PatientAddressCompatible"
       type: object
       required:
-        - user_id
-        - lab_test_id
-        - patient_details
-        - patient_address
+      - user_id
+      - lab_test_id
+      - patient_details
+      - patient_address
       title: CreateOrderRequestCompatible
       description: Schema for the create Order endpoint.
     CreateRegistrableTestkitOrderRequest:
@@ -8247,12 +7465,12 @@ components:
           format: uuid
           title: Lab Test Id
         shipping_details:
-          $ref: '#/components/schemas/ShippingAddress'
+          "$ref": "#/components/schemas/ShippingAddress"
       type: object
       required:
-        - user_id
-        - lab_test_id
-        - shipping_details
+      - user_id
+      - lab_test_id
+      - shipping_details
       title: CreateRegistrableTestkitOrderRequest
     DaySlots:
       properties:
@@ -8262,13 +7480,13 @@ components:
           title: Date
         slots:
           items:
-            $ref: '#/components/schemas/TimeSlot'
+            "$ref": "#/components/schemas/TimeSlot"
           type: array
           title: Slots
       type: object
       required:
-        - date
-        - slots
+      - date
+      - slots
       title: DaySlots
     DemoConnectionCreationPayload:
       properties:
@@ -8279,12 +7497,13 @@ components:
           description: Vital user ID
         provider:
           allOf:
-            - $ref: '#/components/schemas/DemoProviders'
-          description: Demo provider. For more information, please check out our docs (https://docs.tryvital.io/wearables/providers/test_data)
+          - "$ref": "#/components/schemas/DemoProviders"
+          description: Demo provider. For more information, please check out our docs
+            (https://docs.tryvital.io/wearables/providers/test_data)
       type: object
       required:
-        - user_id
-        - provider
+      - user_id
+      - provider
       title: DemoConnectionCreationPayload
     DemoConnectionStatus:
       properties:
@@ -8296,8 +7515,8 @@ components:
           title: Detail
       type: object
       required:
-        - success
-        - detail
+      - success
+      - detail
       title: DemoConnectionStatus
       example:
         success: true
@@ -8305,10 +7524,10 @@ components:
     DemoProviders:
       type: string
       enum:
-        - apple_health_kit
-        - fitbit
-        - freestyle_libre
-        - oura
+      - apple_health_kit
+      - fitbit
+      - freestyle_libre
+      - oura
       title: DemoProviders
       description: An enumeration.
     DeviceV2InDB:
@@ -8332,13 +7551,14 @@ components:
           format: uuid
           title: Id
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingProvider"
       type: object
       required:
-        - provider_id
-        - user_id
-        - source_id
-        - id
+      - provider_id
+      - user_id
+      - source_id
+      - id
+      - source
       title: DeviceV2InDB
     EmailAuthLink:
       properties:
@@ -8346,16 +7566,16 @@ components:
           type: string
           title: Email
         provider:
-          $ref: '#/components/schemas/Providers'
+          "$ref": "#/components/schemas/Providers"
         auth_type:
-          $ref: '#/components/schemas/AuthType'
+          "$ref": "#/components/schemas/AuthType"
         region:
-          $ref: '#/components/schemas/Region'
+          "$ref": "#/components/schemas/Region"
       type: object
       required:
-        - email
-        - provider
-        - auth_type
+      - email
+      - provider
+      - auth_type
       title: EmailAuthLink
     EmailProviderAuthLink:
       properties:
@@ -8363,17 +7583,17 @@ components:
           type: string
           title: Email
         provider:
-          $ref: '#/components/schemas/Providers'
+          "$ref": "#/components/schemas/Providers"
         region:
-          $ref: '#/components/schemas/Region'
+          "$ref": "#/components/schemas/Region"
       type: object
       required:
-        - email
+      - email
       title: EmailProviderAuthLink
     EmailProviders:
       type: string
       enum:
-        - freestyle_libre
+      - freestyle_libre
       title: EmailProviders
       description: An enumeration.
     Energy:
@@ -8381,26 +7601,26 @@ components:
         unit:
           type: string
           enum:
-            - kcal
+          - kcal
           title: Unit
         value:
           type: number
           title: Value
       type: object
       required:
-        - unit
-        - value
+      - unit
+      - value
       title: Energy
     FallbackTimeZone:
       properties:
         id:
           type: string
           title: Id
-          description: |2-
-
-                Fallback time zone of the user, in the form of a valid IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).
-                Used when pulling data from sources that are completely time zone agnostic (e.g., all time is relative to UTC clock, without any time zone attributions on data points).
-                
+          description: "\n    Fallback time zone of the user, in the form of a valid
+            IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).\n
+            \   Used when pulling data from sources that are completely time zone
+            agnostic (e.g., all time is relative to UTC clock, without any time zone
+            attributions on data points).\n    "
         source_slug:
           type: string
           title: Source Slug
@@ -8411,46 +7631,52 @@ components:
           title: Updated At
       type: object
       required:
-        - id
-        - source_slug
-        - updated_at
+      - id
+      - source_slug
+      - updated_at
       title: FallbackTimeZone
     Fats:
       properties:
         saturated:
           type: number
           title: Saturated
+          description: Amount of saturated fats in grams (g)
         monounsaturated:
           type: number
           title: Monounsaturated
+          description: Amount of monounsaturated fats in grams (g)
         polyunsaturated:
           type: number
           title: Polyunsaturated
+          description: Amount of polyunsaturated fats in grams (g)
         omega3:
           type: number
           title: Omega3
+          description: Amount of Omega-3 fatty acids in grams (g)
         omega6:
           type: number
           title: Omega6
+          description: Amount of Omega-6 fatty acids in grams (g)
         total:
           type: number
           title: Total
+          description: Total amount of fats in grams (g)
       type: object
       title: Fats
     Gender:
       type: string
       enum:
-        - female
-        - male
-        - other
-        - unknown
+      - female
+      - male
+      - other
+      - unknown
       title: Gender
       description: An enumeration.
     GetMarkersResponse:
       properties:
         markers:
           items:
-            $ref: '#/components/schemas/ClientFacingMarker'
+            "$ref": "#/components/schemas/ClientFacingMarker"
           type: array
           title: Markers
         total:
@@ -8467,16 +7693,16 @@ components:
           title: Size
       type: object
       required:
-        - markers
-        - total
-        - page
-        - size
+      - markers
+      - total
+      - page
+      - size
       title: GetMarkersResponse
     GetOrdersResponse:
       properties:
         orders:
           items:
-            $ref: '#/components/schemas/ClientFacingOrder'
+            "$ref": "#/components/schemas/ClientFacingOrder"
           type: array
           title: Orders
         total:
@@ -8490,16 +7716,16 @@ components:
           title: Size
       type: object
       required:
-        - orders
-        - total
-        - page
-        - size
+      - orders
+      - total
+      - page
+      - size
       title: GetOrdersResponse
     HTTPValidationError:
       properties:
         detail:
           items:
-            $ref: '#/components/schemas/ValidationError'
+            "$ref": "#/components/schemas/ValidationError"
           type: array
           title: Detail
       type: object
@@ -8508,30 +7734,32 @@ components:
       properties:
         front_image:
           anyOf:
-            - $ref: '#/components/schemas/Jpeg'
-            - $ref: '#/components/schemas/Png'
+          - "$ref": "#/components/schemas/Jpeg"
+          - "$ref": "#/components/schemas/Png"
           title: Front Image
           description: An image of the front of the patient insurance card.
         back_image:
           anyOf:
-            - $ref: '#/components/schemas/Jpeg'
-            - $ref: '#/components/schemas/Png'
+          - "$ref": "#/components/schemas/Jpeg"
+          - "$ref": "#/components/schemas/Png"
           title: Back Image
           description: An image of the back of the patient insurance card.
         patient_signature_image:
           anyOf:
-            - $ref: '#/components/schemas/Jpeg'
-            - $ref: '#/components/schemas/Png'
+          - "$ref": "#/components/schemas/Jpeg"
+          - "$ref": "#/components/schemas/Png"
           title: Patient Signature Image
           description: An image of the patient signature for health insurance billing.
         subjective:
           type: string
           title: Subjective
-          description: Textual description of what are the patient symptoms and attempted treatments.
+          description: Textual description of what are the patient symptoms and attempted
+            treatments.
         assessment_plan:
           type: string
           title: Assessment Plan
-          description: Textual description of what are the physician assessments and testing plans.
+          description: Textual description of what are the physician assessments and
+            testing plans.
         payor_code:
           type: string
           title: Payor Code
@@ -8539,16 +7767,19 @@ components:
         insurance_id:
           type: string
           title: Insurance Id
-          description: Insurance unique number assigned to a patient, usually present on the insurance card.
+          description: Insurance unique number assigned to a patient, usually present
+            on the insurance card.
         responsible_relationship:
           allOf:
-            - $ref: '#/components/schemas/ResponsibleRelationship'
-          description: Relationship between the patient and the insurance contractor. Values can be (Self, Spouse, Other Relationship).
+          - "$ref": "#/components/schemas/ResponsibleRelationship"
+          description: Relationship between the patient and the insurance contractor.
+            Values can be (Self, Spouse, Other Relationship).
         responsible_details:
           allOf:
-            - $ref: '#/components/schemas/PersonDetails'
+          - "$ref": "#/components/schemas/PersonDetails"
           title: Responsible Details
-          description: Responsible details when the value of responsible_relationship is not 'Self'.
+          description: Responsible details when the value of responsible_relationship
+            is not 'Self'.
         diagnosis_codes:
           items:
             type: string
@@ -8569,21 +7800,9 @@ components:
           description: Password for provider
       type: object
       required:
-        - username
-        - password
+      - username
+      - password
       title: IndividualProviderData
-    IngestibleTimeseriesResource:
-      enum:
-        - blood_pressure
-        - blood_oxygen
-        - glucose
-        - heartrate
-        - heartrate_variability
-        - water
-        - caffeine
-        - mindfulness_minutes
-      title: IngestibleTimeseriesResource
-      description: An enumeration.
     Jpeg:
       properties:
         content:
@@ -8593,12 +7812,12 @@ components:
         content_type:
           type: string
           enum:
-            - image/jpeg
+          - image/jpeg
           title: Content Type
       type: object
       required:
-        - content
-        - content_type
+      - content
+      - content_type
       title: Jpeg
     LabResultsMetadata:
       properties:
@@ -8632,13 +7851,20 @@ components:
         date_received:
           type: string
           title: Date Received
+        status:
+          type: string
+          title: Status
+          default: final
+        interpretation:
+          type: string
+          title: Interpretation
       type: object
       required:
-        - age
-        - dob
-        - patient
-        - date_reported
-        - specimen_number
+      - age
+      - dob
+      - patient
+      - date_reported
+      - specimen_number
       title: LabResultsMetadata
       example:
         age: 19
@@ -8651,21 +7877,23 @@ components:
         date_collected: '2022-02-02'
         specimen_number: '123131'
         date_received: '2022-01-01'
+        status: final
+        interpretation: normal
     LabResultsRaw:
       properties:
         metadata:
-          $ref: '#/components/schemas/LabResultsMetadata'
+          "$ref": "#/components/schemas/LabResultsMetadata"
         results:
           anyOf:
-            - items:
-                $ref: '#/components/schemas/BiomarkerResult'
-              type: array
-            - type: object
+          - items:
+              "$ref": "#/components/schemas/BiomarkerResult"
+            type: array
+          - type: object
           title: Results
       type: object
       required:
-        - metadata
-        - results
+      - metadata
+      - results
       title: LabResultsRaw
       example:
         metadata:
@@ -8679,25 +7907,27 @@ components:
           date_collected: '2022-02-02'
           specimen_number: '123131'
           date_received: '2022-01-01'
+          status: final
+          interpretation: normal
         results:
-          '[marker]': {}
+          "[marker]": {}
           ige: {}
           fsh: {}
     LabTestCollectionMethod:
       type: string
       enum:
-        - testkit
-        - walk_in_test
-        - at_home_phlebotomy
+      - testkit
+      - walk_in_test
+      - at_home_phlebotomy
       title: LabTestCollectionMethod
       description: The method used to perform a lab test.
     LabTestSampleType:
       type: string
       enum:
-        - dried_blood_spot
-        - serum
-        - saliva
-        - urine
+      - dried_blood_spot
+      - serum
+      - saliva
+      - urine
       title: LabTestSampleType
       description: The type of sample used to perform a lab test.
     LibreConfig:
@@ -8707,7 +7937,7 @@ components:
           title: Practice Id
       type: object
       required:
-        - practice_id
+      - practice_id
       title: LibreConfig
     LinkTokenBase:
       properties:
@@ -8724,28 +7954,30 @@ components:
           default: {}
       type: object
       required:
-        - token
+      - token
       title: LinkTokenBase
     LinkTokenExchange:
       properties:
-        user_key:
+        user_id:
           type: string
           format: uuid
-          title: User Key
-          description: User id returned by vital create user request. This id should be stored in your database against the user and used for all interactions with the vital api.
+          title: User Id
+          description: User id returned by vital create user request. This id should
+            be stored in your database against the user and used for all interactions
+            with the vital api.
         provider:
-          $ref: '#/components/schemas/Providers'
+          "$ref": "#/components/schemas/Providers"
         redirect_url:
           type: string
           title: Redirect Url
         filter_on_providers:
           items:
-            $ref: '#/components/schemas/Providers'
+            "$ref": "#/components/schemas/Providers"
           type: array
           minItems: 1
       type: object
       required:
-        - user_key
+      - user_id
       title: LinkTokenExchange
     LinkTokenExchangeResponse:
       properties:
@@ -8755,7 +7987,7 @@ components:
           description: Link token to use to launch link widget
       type: object
       required:
-        - link_token
+      - link_token
       title: LinkTokenExchangeResponse
       example:
         link_token: dGVzdCB0ZXN0IHRlc3Q=
@@ -8773,31 +8005,40 @@ components:
           title: Lat
       type: object
       required:
-        - lng
-        - lat
+      - lng
+      - lat
       title: LngLat
     Macros:
       properties:
         carbs:
           type: number
           title: Carbs
+          description: Amount of carbohydrates in grams (g)
         protein:
           type: number
           title: Protein
+          description: Amount of protein in grams (g)
         fats:
-          $ref: '#/components/schemas/Fats'
+          allOf:
+          - "$ref": "#/components/schemas/Fats"
+          title: Fats
+          description: Details of fat content
         alcohol:
           type: number
           title: Alcohol
+          description: Amount of alcohol in grams (g)
         water:
           type: number
           title: Water
+          description: Amount of water in grams (g)
         fibre:
           type: number
           title: Fibre
+          description: Amount of dietary fiber in grams (g)
         sugar:
           type: number
           title: Sugar
+          description: Amount of sugar in grams (g)
       type: object
       title: Macros
     ManualConnectionData:
@@ -8810,26 +8051,27 @@ components:
           title: Provider Id
       type: object
       required:
-        - user_id
+      - user_id
       title: ManualConnectionData
     ManualProviders:
       type: string
       enum:
-        - beurer_ble
-        - omron_ble
-        - accuchek_ble
-        - contour_ble
-        - freestyle_libre_ble
-        - apple_health_kit
-        - manual
-        - health_connect
+      - beurer_ble
+      - omron_ble
+      - accuchek_ble
+      - contour_ble
+      - freestyle_libre_ble
+      - onetouch_ble
+      - apple_health_kit
+      - manual
+      - health_connect
       title: ManualProviders
       description: An enumeration.
     MarkerType:
       type: string
       enum:
-        - biomarker
-        - panel
+      - biomarker
+      - panel
       title: MarkerType
       description: An enumeration.
     MealInDBBase_ClientFacingSource_:
@@ -8859,19 +8101,19 @@ components:
           type: string
           title: Name
         energy:
-          $ref: '#/components/schemas/Energy'
+          "$ref": "#/components/schemas/Energy"
         macros:
-          $ref: '#/components/schemas/Macros'
+          "$ref": "#/components/schemas/Macros"
         micros:
-          $ref: '#/components/schemas/Micros'
+          "$ref": "#/components/schemas/Micros"
         data:
           additionalProperties:
-            $ref: '#/components/schemas/_MealData'
+            "$ref": "#/components/schemas/ClientFacingFood"
           type: object
           title: Data
           default: {}
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingSource"
         created_at:
           type: string
           format: date-time
@@ -8882,16 +8124,16 @@ components:
           title: Updated At
       type: object
       required:
-        - id
-        - user_id
-        - priority_id
-        - source_id
-        - provider_id
-        - timestamp
-        - name
-        - source
-        - created_at
-        - updated_at
+      - id
+      - user_id
+      - priority_id
+      - source_id
+      - provider_id
+      - timestamp
+      - name
+      - source
+      - created_at
+      - updated_at
       title: MealInDBBase[ClientFacingSource]
       example:
         id: 497f6eca-6276-4993-bfeb-53cbbbba6f08
@@ -8943,9 +8185,9 @@ components:
       properties:
         team_id:
           anyOf:
-            - type: string
-            - type: string
-              format: uuid
+          - type: string
+          - type: string
+            format: uuid
           title: Team Id
         number_of_connected_sources:
           type: integer
@@ -8961,7 +8203,7 @@ components:
           default: 0
         number_of_connected_sources_by_week:
           items:
-            $ref: '#/components/schemas/TimeseriesMetricPoint'
+            "$ref": "#/components/schemas/TimeseriesMetricPoint"
           type: array
           title: Number Of Connected Sources By Week
           default: []
@@ -8971,7 +8213,7 @@ components:
           default: 0
       type: object
       required:
-        - team_id
+      - team_id
       title: MetricsResult
     Micros:
       properties:
@@ -8980,158 +8222,89 @@ components:
             type: number
           type: object
           title: Minerals
+          description: Amount of each mineral in grams (g)
         trace_elements:
           additionalProperties:
             type: number
           type: object
           title: Trace Elements
+          description: Amount of each trace element in grams (g)
         vitamins:
           additionalProperties:
             type: number
           type: object
           title: Vitamins
+          description: Amount of each vitamin in grams (g)
       type: object
       title: Micros
     OAuthProviders:
       type: string
       enum:
-        - oura
-        - fitbit
-        - garmin
-        - strava
-        - wahoo
-        - ihealth
-        - withings
-        - google_fit
-        - dexcom_v3
-        - polar
+      - oura
+      - fitbit
+      - garmin
+      - strava
+      - wahoo
+      - ihealth
+      - withings
+      - google_fit
+      - dexcom_v3
+      - polar
+      - cronometer
+      - omron
       title: OAuthProviders
-      description: An enumeration.
-    OpenLoopEvent:
-      properties:
-        resource_id:
-          type: string
-          title: Resource Id
-        resource_id_type:
-          $ref: '#/components/schemas/OpenLoopResourceIdType'
-        event_type:
-          $ref: '#/components/schemas/OpenLoopWebhookType'
-      type: object
-      required:
-        - resource_id
-        - resource_id_type
-        - event_type
-      title: OpenLoopEvent
-    OpenLoopResourceIdType:
-      type: string
-      enum:
-        - Appointment
-        - FormAnswerGroup
-        - Entry
-        - Note
-      title: OpenLoopResourceIdType
-      description: An enumeration.
-    OpenLoopWebhookType:
-      type: string
-      enum:
-        - appointment.created
-        - appointment.updated
-        - appointment.deleted
-        - billing_item.created
-        - billing_item.updated
-        - cms1500.created
-        - cms1500.updated
-        - cms1500.deleted
-        - comment.created
-        - comment.updated
-        - comment.deleted
-        - conversation_membership.viewed
-        - document.created
-        - document.updated
-        - document.deleted
-        - entry.created
-        - entry.updated
-        - entry.deleted
-        - form_answer_group.created
-        - form_answer_group.deleted
-        - form_answer_group.locked
-        - goal.created
-        - goal.updated
-        - goal.deleted
-        - goal_history.created
-        - insurance_authorization.created
-        - insurance_authorization.updated
-        - insurance_authorization.deleted
-        - message.created
-        - message.deleted
-        - metric_entry.created
-        - metric_entry.updated
-        - metric_entry.deleted
-        - patient.created
-        - patient.updated
-        - payment.created
-        - payment.updated
-        - payment.deleted
-        - policy.created
-        - policy.updated
-        - policy.deleted
-        - requested_form_completion.created
-        - requested_form_completion.updated
-        - requested_form_completion.deleted
-        - task.created
-        - task.updated
-        - task.deleted
-      title: OpenLoopWebhookType
       description: An enumeration.
     OrderStatus:
       type: string
       enum:
-        - received.walk_in_test.ordered
-        - received.walk_in_test.requisition_created
-        - completed.walk_in_test.completed
-        - failed.walk_in_test.sample_error
-        - cancelled.walk_in_test.cancelled
-        - received.at_home_phlebotomy.ordered
-        - received.at_home_phlebotomy.requisition_created
-        - collecting_sample.at_home_phlebotomy.appointment_scheduled
-        - collecting_sample.at_home_phlebotomy.draw_completed
-        - collecting_sample.at_home_phlebotomy.appointment_cancelled
-        - completed.at_home_phlebotomy.completed
-        - cancelled.at_home_phlebotomy.cancelled
-        - received.testkit.ordered
-        - received.testkit.awaiting_registration
-        - received.testkit.requisition_created
-        - received.testkit.registered
-        - collecting_sample.testkit.transit_customer
-        - collecting_sample.testkit.out_for_delivery
-        - collecting_sample.testkit.with_customer
-        - collecting_sample.testkit.transit_lab
-        - sample_with_lab.testkit.delivered_to_lab
-        - completed.testkit.completed
-        - failed.testkit.failure_to_deliver_to_customer
-        - failed.testkit.failure_to_deliver_to_lab
-        - failed.testkit.sample_error
-        - failed.testkit.lost
-        - cancelled.testkit.cancelled
-        - cancelled.testkit.do_not_process
+      - received.walk_in_test.ordered
+      - received.walk_in_test.requisition_created
+      - completed.walk_in_test.completed
+      - sample_with_lab.walk_in_test.partial_results
+      - failed.walk_in_test.sample_error
+      - cancelled.walk_in_test.cancelled
+      - received.at_home_phlebotomy.ordered
+      - received.at_home_phlebotomy.requisition_created
+      - collecting_sample.at_home_phlebotomy.appointment_scheduled
+      - collecting_sample.at_home_phlebotomy.draw_completed
+      - collecting_sample.at_home_phlebotomy.appointment_cancelled
+      - completed.at_home_phlebotomy.completed
+      - sample_with_lab.at_home_phlebotomy.partial_results
+      - cancelled.at_home_phlebotomy.cancelled
+      - received.testkit.ordered
+      - received.testkit.awaiting_registration
+      - received.testkit.requisition_created
+      - received.testkit.registered
+      - collecting_sample.testkit.transit_customer
+      - collecting_sample.testkit.out_for_delivery
+      - collecting_sample.testkit.with_customer
+      - collecting_sample.testkit.transit_lab
+      - sample_with_lab.testkit.delivered_to_lab
+      - completed.testkit.completed
+      - failed.testkit.failure_to_deliver_to_customer
+      - failed.testkit.failure_to_deliver_to_lab
+      - failed.testkit.sample_error
+      - failed.testkit.lost
+      - cancelled.testkit.cancelled
+      - cancelled.testkit.do_not_process
       title: OrderStatus
       description: An enumeration.
     OrderTopLevelStatus:
       type: string
       enum:
-        - received
-        - collecting_sample
-        - sample_with_lab
-        - completed
-        - cancelled
-        - failed
+      - received
+      - collecting_sample
+      - sample_with_lab
+      - completed
+      - cancelled
+      - failed
       title: OrderTopLevelStatus
       description: An enumeration.
     PaginatedUsersResponse:
       properties:
         users:
           items:
-            $ref: '#/components/schemas/ClientFacingUser'
+            "$ref": "#/components/schemas/ClientFacingUser"
           type: array
           title: Users
         total:
@@ -9145,10 +8318,10 @@ components:
           title: Limit
       type: object
       required:
-        - users
-        - total
-        - offset
-        - limit
+      - users
+      - total
+      - offset
+      - limit
       title: PaginatedUsersResponse
     PasswordAuthLink:
       properties:
@@ -9159,28 +8332,29 @@ components:
           type: string
           title: Password
         provider:
-          $ref: '#/components/schemas/Providers'
+          "$ref": "#/components/schemas/Providers"
         auth_type:
-          $ref: '#/components/schemas/AuthType'
+          "$ref": "#/components/schemas/AuthType"
       type: object
       required:
-        - username
-        - password
-        - provider
-        - auth_type
+      - username
+      - password
+      - provider
+      - auth_type
       title: PasswordAuthLink
     PasswordProviders:
       type: string
       enum:
-        - whoop
-        - renpho
-        - peloton
-        - zwift
-        - eight_sleep
-        - beurer_api
-        - dexcom
-        - hammerhead
-        - my_fitness_pal
+      - whoop
+      - renpho
+      - peloton
+      - zwift
+      - eight_sleep
+      - beurer_api
+      - dexcom
+      - hammerhead
+      - my_fitness_pal
+      - kardia
       title: PasswordProviders
       description: An enumeration.
     PatientAddressCompatible:
@@ -9212,11 +8386,11 @@ components:
           title: Phone Number
       type: object
       required:
-        - street
-        - city
-        - state
-        - zip
-        - country
+      - street
+      - city
+      - state
+      - zip
+      - country
       title: PatientAddressCompatible
     PatientDetails:
       properties:
@@ -9235,7 +8409,7 @@ components:
           format: date-time
           title: Dob
         gender:
-          $ref: '#/components/schemas/Gender'
+          "$ref": "#/components/schemas/Gender"
         phone_number:
           type: string
           title: Phone Number
@@ -9244,37 +8418,13 @@ components:
           title: Email
       type: object
       required:
-        - first_name
-        - last_name
-        - dob
-        - gender
-        - phone_number
+      - first_name
+      - last_name
+      - dob
+      - gender
+      - phone_number
+      - email
       title: PatientDetails
-    PatientDetailsCompatible:
-      properties:
-        first_name:
-          type: string
-          title: First Name
-        last_name:
-          type: string
-          title: Last Name
-        dob:
-          type: string
-          format: date-time
-          title: Dob
-        gender:
-          $ref: '#/components/schemas/Gender'
-        phone_number:
-          type: string
-          title: Phone Number
-        email:
-          type: string
-          title: Email
-      type: object
-      required:
-        - dob
-        - gender
-      title: PatientDetailsCompatible
     PayorSearchRequest:
       properties:
         insurance_name:
@@ -9285,7 +8435,7 @@ components:
           title: Insurance State
       type: object
       required:
-        - insurance_name
+      - insurance_name
       title: PayorSearchRequest
     PersonDetails:
       properties:
@@ -9296,7 +8446,7 @@ components:
           type: string
           title: Last Name
         address:
-          $ref: '#/components/schemas/Address'
+          "$ref": "#/components/schemas/Address"
         phone_number:
           type: string
           title: Phone Number
@@ -9306,10 +8456,10 @@ components:
           default: Mobile
       type: object
       required:
-        - first_name
-        - last_name
-        - address
-        - phone_number
+      - first_name
+      - last_name
+      - address
+      - phone_number
       title: PersonDetails
     PhlebotomyAreaInfo:
       properties:
@@ -9318,7 +8468,7 @@ components:
           title: Is Served
       type: object
       required:
-        - is_served
+      - is_served
       title: PhlebotomyAreaInfo
     PhysicianClientFacing:
       properties:
@@ -9333,9 +8483,9 @@ components:
           title: Npi
       type: object
       required:
-        - first_name
-        - last_name
-        - npi
+      - first_name
+      - last_name
+      - npi
       title: PhysicianClientFacing
     PhysicianCreateRequest:
       properties:
@@ -9359,15 +8509,15 @@ components:
           default: []
         signature_image:
           anyOf:
-            - $ref: '#/components/schemas/Jpeg'
-            - $ref: '#/components/schemas/Png'
+          - "$ref": "#/components/schemas/Jpeg"
+          - "$ref": "#/components/schemas/Png"
           title: Signature Image
           description: An image of the physician signature for health insurance billing
       type: object
       required:
-        - first_name
-        - last_name
-        - npi
+      - first_name
+      - last_name
+      - npi
       title: PhysicianCreateRequest
     PhysicianCreateRequestBase:
       properties:
@@ -9391,17 +8541,10 @@ components:
           default: []
       type: object
       required:
-        - first_name
-        - last_name
-        - npi
+      - first_name
+      - last_name
+      - npi
       title: PhysicianCreateRequestBase
-    PhysicianNetworkT:
-      type: string
-      enum:
-        - WHEEL
-        - OPENLOOP
-      title: PhysicianNetworkT
-      description: An enumeration.
     Png:
       properties:
         content:
@@ -9411,17 +8554,17 @@ components:
         content_type:
           type: string
           enum:
-            - image/png
+          - image/png
           title: Content Type
       type: object
       required:
-        - content
-        - content_type
+      - content
+      - content_type
       title: Png
     PostOrderResponse:
       properties:
         order:
-          $ref: '#/components/schemas/ClientFacingOrder'
+          "$ref": "#/components/schemas/ClientFacingOrder"
         status:
           type: string
           title: Status
@@ -9430,84 +8573,10 @@ components:
           title: Message
       type: object
       required:
-        - order
-        - status
-        - message
+      - order
+      - status
+      - message
       title: PostOrderResponse
-    Priority:
-      properties:
-        id:
-          type: integer
-          title: Id
-        priority:
-          type: integer
-          title: Priority
-        team_id:
-          type: string
-          format: uuid
-          title: Team Id
-        source_id:
-          type: integer
-          title: Source Id
-        data_type:
-          type: string
-          title: Data Type
-      type: object
-      required:
-        - id
-        - priority
-        - team_id
-        - source_id
-      title: Priority
-    PriorityCreate:
-      properties:
-        id:
-          type: integer
-          title: Id
-        priority:
-          type: integer
-          title: Priority
-        team_id:
-          type: string
-          format: uuid
-          title: Team Id
-        source_id:
-          type: integer
-          title: Source Id
-        data_type:
-          type: string
-          title: Data Type
-      type: object
-      required:
-        - priority
-        - team_id
-        - source_id
-      title: PriorityCreate
-    PriorityInDB:
-      properties:
-        id:
-          type: integer
-          title: Id
-        priority:
-          type: integer
-          title: Priority
-        team_id:
-          type: string
-          format: uuid
-          title: Team Id
-        source_id:
-          type: integer
-          title: Source Id
-        data_type:
-          type: string
-          title: Data Type
-      type: object
-      required:
-        - id
-        - priority
-        - team_id
-        - source_id
-      title: PriorityInDB
     ProfileInDb:
       properties:
         data:
@@ -9529,22 +8598,22 @@ components:
           format: uuid
           title: Id
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingProvider"
         updated_at:
           type: string
           format: date-time
           title: Updated At
       type: object
       required:
-        - user_id
-        - source_id
-        - id
-        - source
+      - user_id
+      - source_id
+      - id
+      - source
       title: ProfileInDb
     ProviderLinkResponse:
       properties:
         provider:
-          $ref: '#/components/schemas/PasswordProviders'
+          "$ref": "#/components/schemas/PasswordProviders"
         connected:
           type: boolean
           title: Connected
@@ -9553,170 +8622,175 @@ components:
           title: Provider Id
       type: object
       required:
-        - provider
-        - connected
+      - provider
+      - connected
       title: ProviderLinkResponse
       example:
         provider: zwift
         connected: true
-        provider_id: <provider_id>
+        provider_id: "<provider_id>"
     Providers:
       type: string
       enum:
-        - oura
-        - fitbit
-        - garmin
-        - whoop
-        - strava
-        - renpho
-        - peloton
-        - wahoo
-        - zwift
-        - freestyle_libre
-        - freestyle_libre_ble
-        - eight_sleep
-        - withings
-        - apple_health_kit
-        - manual
-        - ihealth
-        - google_fit
-        - beurer_api
-        - beurer_ble
-        - omron_ble
-        - accuchek_ble
-        - contour_ble
-        - dexcom
-        - dexcom_v3
-        - hammerhead
-        - my_fitness_pal
-        - health_connect
-        - polar
+      - oura
+      - fitbit
+      - garmin
+      - whoop
+      - strava
+      - renpho
+      - peloton
+      - wahoo
+      - zwift
+      - freestyle_libre
+      - freestyle_libre_ble
+      - eight_sleep
+      - withings
+      - apple_health_kit
+      - manual
+      - ihealth
+      - google_fit
+      - beurer_api
+      - beurer_ble
+      - omron
+      - omron_ble
+      - onetouch_ble
+      - accuchek_ble
+      - contour_ble
+      - dexcom
+      - dexcom_v3
+      - hammerhead
+      - my_fitness_pal
+      - health_connect
+      - polar
+      - cronometer
+      - kardia
       title: Providers
       description: An enumeration.
     RawActivity:
       properties:
         activity:
           items:
-            $ref: '#/components/schemas/ActivityV2InDB'
+            "$ref": "#/components/schemas/ActivityV2InDB"
           type: array
           title: Activity
       type: object
       required:
-        - activity
+      - activity
       title: Activity Data
       example:
         activity:
-          - timestamp: '2023-08-28T19:42:26.793490+00:00'
-            data:
-              data: ...provider_specific_data
-            provider_id: 57e31f03-4999-45f5-bc56-1b2196ac1a76
-            user_id: 27bfaf15-1aaf-4cac-a0f4-cd421f10b968
-            source_id: 1
-            priority_id: 1
+        - timestamp: '2023-10-30T18:44:06.982310+00:00'
+          data:
+            data: "...provider_specific_data"
+          provider_id: b862f04a-40ea-417a-a4d6-e707f760999e
+          user_id: 2d0930a6-eea5-4008-a37d-78745bf6a247
+          source_id: 1
+          priority_id: 1
     RawBody:
       properties:
         body:
           items:
-            $ref: '#/components/schemas/BodyV2InDB'
+            "$ref": "#/components/schemas/BodyV2InDB"
           type: array
           title: Body
       type: object
       required:
-        - body
+      - body
       title: Body Data
       example:
         body:
-          - timestamp: '2023-08-28T19:42:26.803965+00:00'
-            data:
-              data: ...provider_specific_data
-            provider_id: f74b85ba-5925-4cf9-9b09-caff0915f4e2
-            user_id: 9802f689-3b82-42f9-8127-b0793f816b94
-            source_id: 1
-            priority_id: 1
+        - timestamp: '2023-10-30T18:44:06.989480+00:00'
+          data:
+            data: "...provider_specific_data"
+          provider_id: 6fbf4223-c363-487e-b589-6a1920ec4570
+          user_id: 59423381-4ab4-4cea-ac91-301654530a77
+          source_id: 1
+          priority_id: 1
     RawDevices:
       properties:
         devices:
           items:
-            $ref: '#/components/schemas/DeviceV2InDB'
+            "$ref": "#/components/schemas/DeviceV2InDB"
           type: array
           title: Devices
       type: object
       required:
-        - devices
+      - devices
       title: Raw Devices Data
       example:
         devices:
-          - data:
-              data: ...provider_specific_data
-            provider_id: a19fac79-3b04-4e97-b8e5-9782de22e133
-            user_id: 11ad66d6-1c28-4ff8-9336-e38ef387d750
-            source_id: 1
+        - data:
+            data: "...provider_specific_data"
+          provider_id: a5158a5f-cd4b-493c-ad5b-14c10713e51e
+          user_id: 238dab91-38a6-4887-b437-f141460f54cd
+          source_id: 1
     RawProfile:
       properties:
         profile:
-          $ref: '#/components/schemas/ProfileInDb'
+          "$ref": "#/components/schemas/ProfileInDb"
       type: object
       required:
-        - profile
+      - profile
       title: Profile Data
       example:
         profile:
-          - data:
-              data: ...provider_specific_data
-            provider_id: fb5046eb-8de8-4bf9-b8db-372865072179
-            user_id: 2719010e-0828-4460-b9c9-59399742f9f0
-            source_id: 1
+        - data:
+            data: "...provider_specific_data"
+          provider_id: e0deec04-7e3b-4748-aca7-fae2de89df3c
+          user_id: d58e6aab-de0c-4ec4-b1f2-1c1f20f7afa1
+          source_id: 1
     RawSleep:
       properties:
         sleep:
           items:
-            $ref: '#/components/schemas/SleepV2InDB'
+            "$ref": "#/components/schemas/SleepV2InDB"
           type: array
           title: Sleep
       type: object
       required:
-        - sleep
+      - sleep
       title: Raw Sleep data
       example:
         sleep:
-          - timestamp: '2023-08-28T19:42:26.863202+00:00'
-            data:
-              data: ...provider_specific_data
-            provider_id: cbd41204-89e2-4540-8a4f-ba29e54e31f8
-            user_id: a04e9adb-4819-46e8-8124-65d499d65827
-            source_id: 1
-            priority_id: 1
+        - timestamp: '2023-10-30T18:44:07.022689+00:00'
+          data:
+            data: "...provider_specific_data"
+          provider_id: 25e0db05-5879-403c-a594-d13b1dec1bd9
+          user_id: df8cbeaf-029e-4944-a6ef-1dac5735c601
+          source_id: 1
+          priority_id: 1
     RawWorkout:
       properties:
         workouts:
           items:
-            $ref: '#/components/schemas/WorkoutV2InDB'
+            "$ref": "#/components/schemas/WorkoutV2InDB"
           type: array
           title: Workouts
       type: object
       required:
-        - workouts
+      - workouts
       title: Workouts Data
       example:
         workouts:
-          - timestamp: '2023-08-28T19:42:26.885338+00:00'
-            data:
-              provider_specific: ..._data
-            provider_id: 1ee6cb1f-beb0-414d-bb4a-a526cc4c4ac9
-            user_id: 9b4ab15c-a5a6-4794-9a6f-b6d8586fba26
-            source_id: 1
-            priority_id: 1
-            sport_id: 3
+        - timestamp: '2023-10-30T18:44:07.034431+00:00'
+          data:
+            provider_specific: "..._data"
+          provider_id: 962ba33b-3838-4dad-8003-b664f84287e6
+          user_id: 968d834f-8d48-4122-a24e-1ef469402b87
+          source_id: 1
+          priority_id: 1
+          sport_id: 3
     Region:
       type: string
       enum:
-        - us
-        - eu
-        - sg
-        - de
-        - au
-        - br
-        - nl
+      - us
+      - eu
+      - sg
+      - de
+      - au
+      - br
+      - nl
+      - fr
       title: Region
       description: An enumeration.
     RegisterTestkitRequest:
@@ -9729,97 +8803,39 @@ components:
           type: string
           title: Sample Id
         patient_details:
-          $ref: '#/components/schemas/PatientDetails'
+          "$ref": "#/components/schemas/PatientDetails"
         patient_address:
-          $ref: '#/components/schemas/PatientAddressCompatible'
+          "$ref": "#/components/schemas/PatientAddressCompatible"
         physician:
-          $ref: '#/components/schemas/PhysicianCreateRequestBase'
+          "$ref": "#/components/schemas/PhysicianCreateRequestBase"
         consents:
           items:
-            $ref: '#/components/schemas/Consent'
+            "$ref": "#/components/schemas/Consent"
           type: array
           title: Consents
       type: object
       required:
-        - user_id
-        - sample_id
-        - patient_details
-        - patient_address
+      - user_id
+      - sample_id
+      - patient_details
+      - patient_address
       title: RegisterTestkitRequest
     ResponsibleRelationship:
       type: string
       enum:
-        - Self
-        - Spouse
-        - Other Relationship
+      - Self
+      - Spouse
+      - Other Relationship
       title: ResponsibleRelationship
       description: An enumeration.
-    ShipmentWebhookUpdate:
-      properties:
-        webhook_type:
-          type: string
-          enum:
-            - Shipment Update
-          title: Webhook Type
-        fulfillment:
-          $ref: '#/components/schemas/_Fulfillment'
-      type: object
-      required:
-        - webhook_type
-        - fulfillment
-      title: ShipmentWebhookUpdate
-      description: |-
-        example: {
-            "test": "0",
-            "webhook_type": "Shipment Update",
-            "fulfillment": {
-                "shipment_id": 263653409,
-                "shipment_uuid": "U2hpcG1lbnQ6MjYzNjUzNDA5",
-                "warehouse": "Primary",
-                "warehouse_id": 3141,
-                "warehouse_uuid": "V2FyZWhvdXNlOjMxNDE=",
-                "webhook_type": "Shipment Update",
-                "partner_order_id": "Order #243",
-                "order_number": "Order #243",
-                "tracking_number": "Pickup",
-                "line_items": [
-                    {
-                        "id": "Order #243-355933727",
-                        "shiphero_id": 708252296,
-                        "quantity": 50,
-                        "sku": "1122334581",
-                        "serial_numbers": [],
-                        "customs_description": "a description",
-                        "package": "Package #1",
-                        "lot_id": null,
-                        "lot_name": null,
-                        "lot_expiration": null
-                    }
-                ],
-                "custom_tracking_url": "https://foo.bar",
-                "shipping_method": "UPS Ground",
-                "shipping_carrier": "UPS",
-                "shipping_address": {
-                  "name": "tomas wingord",
-                  "address1": "55 W RAILROAD AVE BLDG 4",
-                  "address2": "BLDG 4",
-                  "address_city": "GARNERVILLE",
-                  "address_zip": "10923-1261",
-                  "address_state": "NY",
-                  "address_country": "US"
-                },
-                "package": {
-                    "length": 1,
-                    "width": 1,
-                    "height": 1,
-                    "weight": 12000
-                },
-                "completed": true,
-                "created_at": "2022-05-24 18:20:15",
-                "order_uuid": "T3JkZXI6MjcyMjcxNzA2",
-                "order_gift_note": ""
-            }
-        }
+    ResultType:
+      type: string
+      enum:
+      - numeric
+      - range
+      - comment
+      title: ResultType
+      description: An enumeration.
     ShippingAddress:
       properties:
         receiver_name:
@@ -9848,13 +8864,13 @@ components:
           title: Phone Number
       type: object
       required:
-        - receiver_name
-        - first_line
-        - city
-        - state
-        - zip
-        - country
-        - phone_number
+      - receiver_name
+      - first_line
+      - city
+      - state
+      - zip
+      - country
+      - phone_number
       title: ShippingAddress
     SleepV2InDB:
       properties:
@@ -9884,18 +8900,18 @@ components:
           format: uuid
           title: Id
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingProvider"
         priority:
           type: integer
           title: Priority
       type: object
       required:
-        - timestamp
-        - provider_id
-        - user_id
-        - source_id
-        - id
-        - source
+      - timestamp
+      - provider_id
+      - user_id
+      - source_id
+      - id
+      - source
       title: SleepV2InDB
     Source:
       properties:
@@ -9919,8 +8935,12 @@ components:
           title: Oauth Url
         auth_type:
           allOf:
-            - $ref: '#/components/schemas/SourceAuthType'
+          - "$ref": "#/components/schemas/SourceAuthType"
           default: oauth
+        source_type:
+          allOf:
+          - "$ref": "#/components/schemas/SourceType"
+          default: device
         is_active:
           type: boolean
           title: Is Active
@@ -9933,15 +8953,15 @@ components:
           title: Id
       type: object
       required:
-        - name
-        - slug
-        - description
-        - logo
-        - id
+      - name
+      - slug
+      - description
+      - logo
+      - id
       title: Provider
       example:
         name: Garmin
-        slug: hamin
+        slug: garmin
         logo: https://garmin.com
         description: Garmin Watches
         oauth_url: https://garmin_aouth_url.com
@@ -9950,18 +8970,18 @@ components:
     SourceAuthType:
       type: string
       enum:
-        - oauth
-        - team_oauth
-        - sdk
-        - password
-        - email
-        - app
-        - ''
-      x-fern-enum: 
-        '': 
-          name: Empty
+      - oauth
+      - team_oauth
+      - sdk
+      - password
+      - email
+      - app
+      - ''
       title: SourceAuthType
       description: An enumeration.
+      x-fern-enum:
+        '':
+          name: Empty
     SourceLink:
       properties:
         id:
@@ -9984,7 +9004,7 @@ components:
           title: Oauth Url
         auth_type:
           allOf:
-            - $ref: '#/components/schemas/SourceAuthType'
+          - "$ref": "#/components/schemas/SourceAuthType"
           default: oauth
         form_components:
           type: object
@@ -9992,249 +9012,34 @@ components:
           default: {}
       type: object
       required:
-        - id
-        - name
-        - slug
-        - description
-        - logo
+      - id
+      - name
+      - slug
+      - description
+      - logo
       title: SourceLink
+    SourceType:
+      type: string
+      enum:
+      - app
+      - ble
+      - device
+      - lab
+      - provider
+      title: SourceType
+      description: An enumeration.
     TeamConfig:
       properties:
         libreview:
-          $ref: '#/components/schemas/LibreConfig'
+          "$ref": "#/components/schemas/LibreConfig"
         texts_enabled:
           type: boolean
           title: Texts Enabled
           default: false
       type: object
       required:
-        - libreview
+      - libreview
       title: TeamConfig
-    TeamCreate:
-      properties:
-        svix_app_id:
-          type: string
-          title: Svix App Id
-        client_id:
-          type: string
-          title: Client Id
-          default: ''
-        client_secret:
-          type: string
-          title: Client Secret
-          default: ''
-        api_key:
-          type: string
-          title: Api Key
-          default: ''
-        airtable_api_key:
-          type: string
-          title: Airtable Api Key
-          default: ''
-        airtable_base_id:
-          type: string
-          title: Airtable Base Id
-          default: ''
-        webhook_secret:
-          type: string
-          title: Webhook Secret
-        ff_wheel_enabled:
-          type: boolean
-          title: Ff Wheel Enabled
-          default: false
-        ff_apple_mobile_app_enabled:
-          type: boolean
-          title: Ff Apple Mobile App Enabled
-          default: false
-        lab_tests_patient_communication_enabled:
-          type: boolean
-          title: Lab Tests Patient Communication Enabled
-          default: true
-        lab_test_delegated_flow_enabled:
-          type: boolean
-          title: Lab Test Delegated Flow Enabled
-          default: false
-        physician_network:
-          allOf:
-            - $ref: '#/components/schemas/PhysicianNetworkT'
-          default: OPENLOOP
-        id:
-          type: string
-          format: uuid
-          title: Id
-        name:
-          type: string
-          title: Name
-        subscription_status:
-          type: string
-          title: Subscription Status
-      type: object
-      required:
-        - name
-      title: TeamCreate
-    TeamInDB:
-      properties:
-        svix_app_id:
-          type: string
-          title: Svix App Id
-        client_id:
-          type: string
-          title: Client Id
-          default: ''
-        client_secret:
-          type: string
-          title: Client Secret
-          default: ''
-        api_key:
-          type: string
-          title: Api Key
-        airtable_api_key:
-          type: string
-          title: Airtable Api Key
-          default: ''
-        airtable_base_id:
-          type: string
-          title: Airtable Base Id
-          default: ''
-        webhook_secret:
-          type: string
-          title: Webhook Secret
-        ff_wheel_enabled:
-          type: boolean
-          title: Ff Wheel Enabled
-          default: false
-        ff_apple_mobile_app_enabled:
-          type: boolean
-          title: Ff Apple Mobile App Enabled
-          default: false
-        lab_tests_patient_communication_enabled:
-          type: boolean
-          title: Lab Tests Patient Communication Enabled
-        lab_test_delegated_flow_enabled:
-          type: boolean
-          title: Lab Test Delegated Flow Enabled
-          default: false
-        physician_network:
-          allOf:
-            - $ref: '#/components/schemas/PhysicianNetworkT'
-          default: OPENLOOP
-        id:
-          type: string
-          format: uuid
-          title: Id
-        name:
-          type: string
-          title: Name
-        users:
-          items:
-            $ref: '#/components/schemas/TeamUser'
-          type: array
-          title: Users
-          default: []
-        connected_sources:
-          items:
-            $ref: '#/components/schemas/ConnectedSourceClientFacingRedacted'
-          type: array
-          title: Connected Sources
-          default: []
-        configuration:
-          type: object
-          title: Configuration
-        priorities:
-          items:
-            $ref: '#/components/schemas/PriorityInDB'
-          type: array
-          title: Priorities
-          default: []
-        subscription_status:
-          type: string
-          title: Subscription Status
-        api_keys:
-          items:
-            $ref: '#/components/schemas/ApiKeyInDB'
-          type: array
-          title: Api Keys
-        logo_url:
-          type: string
-          title: Logo Url
-      type: object
-      required:
-        - lab_tests_patient_communication_enabled
-        - id
-        - name
-        - configuration
-      title: TeamInDB
-    TeamUpdate:
-      properties:
-        lab_tests_patient_communication_enabled:
-          type: boolean
-          title: Lab Tests Patient Communication Enabled
-        subscription_status:
-          type: string
-          title: Subscription Status
-        logo_url:
-          type: string
-          title: Logo Url
-      additionalProperties: false
-      type: object
-      title: TeamUpdate
-    TeamUser:
-      properties:
-        id:
-          type: string
-          format: uuid
-          title: Id
-          description: Alias id to a specific field.
-        team_id:
-          type: string
-          format: uuid
-          title: Team Id
-          description: Your team id.
-        client_user_id:
-          type: string
-          title: Client User Id
-          description: A unique ID representing the end user. Typically this will be a user ID from your application. Personally identifiable information, such as an email address or phone number, should not be used in the client_user_id.
-        created_on:
-          type: string
-          format: date-time
-          title: Created On
-          description: When your item is created
-        connected_sources:
-          items:
-            $ref: '#/components/schemas/ConnectedSourceClientFacing'
-          type: array
-          title: Connected Sources
-          description: A list of the users connected sources.
-        fallback_time_zone:
-          allOf:
-            - $ref: '#/components/schemas/FallbackTimeZone'
-          title: Fallback Time Zone
-          description: |2-
-
-                Fallback time zone of the user, in the form of a valid IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).
-                Used when pulling data from sources that are completely time zone agnostic (e.g., all time is relative to UTC clock, without any time zone attributions on data points).
-                
-      type: object
-      required:
-        - id
-        - team_id
-        - client_user_id
-        - created_on
-        - connected_sources
-      title: User
-      example:
-        user_id: ff06be40-912a-4177-abaf-a91fdbd4de28
-        team_id: e3b6db9f-3000-4ce9-aee7-5ba80c254ce7
-        client_user_id: db1e7e31-72c3-4c26-a418-29d32cb6b308
-        connected_sources:
-          - source:
-              name: Oura
-              slug: oura
-              logo: logo_url
-        fallback_time_zone:
-          id: Europe/London
-          source_slug: manual
-          updated_at: '2023-08-28T19:42:32.575459+00:00'
     TimeSlot:
       properties:
         booking_key:
@@ -10244,10 +9049,12 @@ components:
           type: string
           format: date-time
           title: Start
+          description: Time is in UTC
         end:
           type: string
           format: date-time
           title: End
+          description: Time is in UTC
         expires_at:
           type: string
           format: date-time
@@ -10263,11 +9070,11 @@ components:
           title: Num Appointments Available
       type: object
       required:
-        - start
-        - end
-        - price
-        - is_priority
-        - num_appointments_available
+      - start
+      - end
+      - price
+      - is_priority
+      - num_appointments_available
       title: TimeSlot
     TimeseriesMetricPoint:
       properties:
@@ -10280,44 +9087,42 @@ components:
           title: Value
       type: object
       required:
-        - date
-        - value
+      - date
+      - value
       title: TimeseriesMetricPoint
     TimeseriesResource:
       type: string
       enum:
-        - calories_active
-        - calories_basal
-        - distance
-        - blood_oxygen
-        - blood_pressure
-        - body/fat
-        - body/weight
-        - cholesterol
-        - cholesterol/ldl
-        - cholesterol/hdl
-        - cholesterol/total
-        - cholesterol/triglycerides
-        - floors_climbed
-        - glucose
-        - heartrate
-        - hrv
-        - heartrate_variability
-        - hypnogram
-        - ige
-        - igg
-        - respiratory_rate
-        - steps
-        - stress_level
-        - vo2_max
-        - water
-        - caffeine
-        - mindfulness_minutes
+      - calories_active
+      - calories_basal
+      - distance
+      - blood_oxygen
+      - blood_pressure
+      - body/fat
+      - body/weight
+      - cholesterol
+      - cholesterol/ldl
+      - cholesterol/hdl
+      - cholesterol/total
+      - cholesterol/triglycerides
+      - electrocardiogram_voltage
+      - floors_climbed
+      - glucose
+      - heartrate
+      - hrv
+      - heartrate_variability
+      - hypnogram
+      - ige
+      - igg
+      - respiratory_rate
+      - steps
+      - stress_level
+      - vo2_max
+      - water
+      - caffeine
+      - mindfulness_minutes
       title: TimeseriesResource
-      description: |-
-        The REST API name of timeseries resources
-        Should match vital_core.ee.schemas.webhook.ClientFacingResource unless there is a strong
-        reason not to.
+      description: An enumeration.
     USAddress:
       properties:
         first_line:
@@ -10331,59 +9136,55 @@ components:
           title: City
         state:
           type: string
-          pattern: ^[A-Z]{2}$
+          pattern: "^[A-Z]{2}$"
           title: State
         zip_code:
           type: string
-          pattern: ^\d{5}$
+          pattern: "^\\d{5}$"
           title: Zip Code
         unit:
           type: string
           title: Unit
+          description: Deprecated. Use `second_line` instead to provide the unit number.
+            Subject to removal after 20 Nov 2023.
+          deprecated: true
       type: object
       required:
-        - first_line
-        - city
-        - state
-        - zip_code
+      - first_line
+      - city
+      - state
+      - zip_code
       title: USAddress
-    UpdateApiKeyBody:
-      properties:
-        label:
-          type: string
-          title: Label
-      type: object
-      required:
-        - label
-      title: UpdateApiKeyBody
     UserCreateBody:
       properties:
         client_user_id:
           type: string
           title: Client User Id
-          description: A unique ID representing the end user. Typically this will be a user ID from your application. Personally identifiable information, such as an email address or phone number, should not be used in the client_user_id.
+          description: A unique ID representing the end user. Typically this will
+            be a user ID from your application. Personally identifiable information,
+            such as an email address or phone number, should not be used in the client_user_id.
         fallback_time_zone:
           type: string
           title: Fallback Time Zone
-          description: |2-
-
-                Fallback time zone of the user, in the form of a valid IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).
-                Used when pulling data from sources that are completely time zone agnostic (e.g., all time is relative to UTC clock, without any time zone attributions on data points).
-                
+          description: "\n    Fallback time zone of the user, in the form of a valid
+            IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).\n
+            \   Used when pulling data from sources that are completely time zone
+            agnostic (e.g., all time is relative to UTC clock, without any time zone
+            attributions on data points).\n    "
       type: object
       required:
-        - client_user_id
+      - client_user_id
       title: UserCreateBody
     UserPatchBody:
       properties:
         fallback_time_zone:
           type: string
           title: Fallback Time Zone
-          description: |2-
-
-                Fallback time zone of the user, in the form of a valid IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).
-                Used when pulling data from sources that are completely time zone agnostic (e.g., all time is relative to UTC clock, without any time zone attributions on data points).
-                
+          description: "\n    Fallback time zone of the user, in the form of a valid
+            IANA tzdatabase identifier (e.g., `Europe/London` or `America/Los_Angeles`).\n
+            \   Used when pulling data from sources that are completely time zone
+            agnostic (e.g., all time is relative to UTC clock, without any time zone
+            attributions on data points).\n    "
       type: object
       title: UserPatchBody
     UserRefreshErrorResponse:
@@ -10391,14 +9192,16 @@ components:
         success:
           type: boolean
           enum:
-            - false
+          - false
           title: Success
           description: Whether operation was successful or not
         user_id:
           type: string
           format: uuid
           title: User Id
-          description: A unique ID representing the end user. Typically this will be a user ID from your application. Personally identifiable information, such as an email address or phone number, should not be used in the client_user_id.
+          description: A unique ID representing the end user. Typically this will
+            be a user ID from your application. Personally identifiable information,
+            such as an email address or phone number, should not be used in the client_user_id.
         error:
           type: string
           title: Error
@@ -10409,13 +9212,13 @@ components:
           title: Failed Sources
       type: object
       required:
-        - success
-        - user_id
-        - error
+      - success
+      - user_id
+      - error
       title: UserRefreshErrorResponse
       example:
         success: false
-        user_id: de8712b5-ea75-4421-90c3-282e29327f72
+        user_id: 294ee8ec-5152-416b-88df-15512c48cf6f
         error: user has no connected sources
         failed_sources: []
     UserRefreshSuccessResponse:
@@ -10423,14 +9226,16 @@ components:
         success:
           type: boolean
           enum:
-            - true
+          - true
           title: Success
           description: Whether operation was successful or not
         user_id:
           type: string
           format: uuid
           title: User Id
-          description: A unique ID representing the end user. Typically this will be a user ID from your application. Personally identifiable information, such as an email address or phone number, should not be used in the client_user_id.
+          description: A unique ID representing the end user. Typically this will
+            be a user ID from your application. Personally identifiable information,
+            such as an email address or phone number, should not be used in the client_user_id.
         refreshed_sources:
           items:
             type: string
@@ -10443,22 +9248,51 @@ components:
           title: Failed Sources
       type: object
       required:
-        - success
-        - user_id
-        - refreshed_sources
-        - failed_sources
+      - success
+      - user_id
+      - refreshed_sources
+      - failed_sources
       title: UserRefreshSuccessResponse
       example:
         success: true
-        user_id: e93d9faa-5734-4172-9ac0-add77f1d35fb
+        user_id: df39a16f-88ba-4dcd-81d7-e9127e0b14ec
         refreshed_sources:
-          - Withings/workouts
-          - Withings/sleep
-          - Withings/body
-          - Withings/vitals/blood_pressure
-          - Withings/activity
+        - Withings/workouts
+        - Withings/sleep
+        - Withings/body
+        - Withings/vitals/blood_pressure
+        - Withings/activity
         failed_sources:
-          - Oura/sleep
+        - Oura/sleep
+    UserSignInToken:
+      properties:
+        public_key:
+          type: string
+          title: Public Key
+        user_token:
+          type: string
+          title: User Token
+      type: object
+      required:
+      - public_key
+      - user_token
+      title: UserSignInToken
+    UserSignInTokenResponse:
+      properties:
+        user_id:
+          type: string
+          format: uuid
+          title: User Id
+        sign_in_token:
+          anyOf:
+          - "$ref": "#/components/schemas/UserSignInToken"
+          - type: string
+          title: Sign In Token
+      type: object
+      required:
+      - user_id
+      - sign_in_token
+      title: UserSignInTokenResponse
     UserSuccessResponse:
       properties:
         success:
@@ -10467,7 +9301,7 @@ components:
           description: Whether operation was successful or not
       type: object
       required:
-        - success
+      - success
       title: UserSuccessResponse
       example:
         success: true
@@ -10476,8 +9310,8 @@ components:
         loc:
           items:
             anyOf:
-              - type: string
-              - type: integer
+            - type: string
+            - type: integer
           type: array
           title: Location
         msg:
@@ -10488,61 +9322,25 @@ components:
           title: Error Type
       type: object
       required:
-        - loc
-        - msg
-        - type
+      - loc
+      - msg
+      - type
       title: ValidationError
     VitalTokenCreatedResponse:
       properties:
         code:
           type: string
-          pattern: ^(sk|pk)(eu|us)([\da-f]{8})
+          pattern: "^(sk|pk)(eu|us)([\\da-f]{8})"
           title: Code
         exchange_url:
           type: string
-          pattern: ^tryvital\:\/\/tryvital\?code\=(sk|pk)(eu|us)([\da-f]{8})$
+          pattern: "^tryvital\\:\\/\\/tryvital\\?code\\=(sk|pk)(eu|us)([\\da-f]{8})$"
           title: Exchange Url
       type: object
       required:
-        - code
-        - exchange_url
+      - code
+      - exchange_url
       title: VitalTokenCreatedResponse
-    VitalTokenExchangeResponse:
-      properties:
-        api_key:
-          type: string
-          title: Api Key
-        region:
-          $ref: '#/components/schemas/Region'
-        environment:
-          type: string
-          title: Environment
-        user_id:
-          type: string
-          format: uuid
-          title: User Id
-        team:
-          $ref: '#/components/schemas/VitalTokenExchangeTeamResponse'
-      type: object
-      required:
-        - api_key
-        - region
-        - environment
-        - user_id
-        - team
-      title: VitalTokenExchangeResponse
-    VitalTokenExchangeTeamResponse:
-      properties:
-        name:
-          type: string
-          title: Name
-        logo_url:
-          type: string
-          title: Logo Url
-      type: object
-      required:
-        - name
-      title: VitalTokenExchangeTeamResponse
     WorkoutV2InDB:
       properties:
         timestamp:
@@ -10574,40 +9372,34 @@ components:
           type: integer
           title: Sport Id
         source:
-          $ref: '#/components/schemas/ClientFacingSource'
+          "$ref": "#/components/schemas/ClientFacingProvider"
         sport:
-          $ref: '#/components/schemas/ClientFacingSport'
+          "$ref": "#/components/schemas/ClientFacingSport"
       type: object
       required:
-        - timestamp
-        - provider_id
-        - user_id
-        - source_id
-        - id
-        - sport_id
-        - source
-        - sport
+      - timestamp
+      - provider_id
+      - user_id
+      - source_id
+      - id
+      - sport_id
+      - source
+      - sport
       title: WorkoutV2InDB
-    _Fulfillment:
-      properties:
-        order_uuid:
-          type: string
-          title: Order Uuid
-        order_number:
-          type: string
-          title: Order Number
-      type: object
-      required:
-        - order_uuid
-        - order_number
-      title: _Fulfillment
-    _MealData:
-      properties:
-        energy:
-          $ref: '#/components/schemas/Energy'
-        macros:
-          $ref: '#/components/schemas/Macros'
-        micros:
-          $ref: '#/components/schemas/Micros'
-      type: object
-      title: _MealData
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-vital-api-key
+      description: API key based authentication
+security:
+  apiKeyAuth: []
+servers:
+- url: https://api.tryvital.io
+  x-fern-server-name: Production
+- url: https://api.eu.tryvital.io
+  x-fern-server-name: ProductionEU
+- url: https://api.sandbox.tryvital.io
+  x-fern-server-name: Sandbox
+- url: https://api.sandbox.eu.tryvital.io
+  x-fern-server-name: SandboxEU


### PR DESCRIPTION
- from version 0.1.982 to 0.2.86
- in version 0.1.982, there were 178 instances of `x-fern-...`. In version 0.2.86, there are 171 instances. This makes sense as the OpenAPI spec was shortened between versions (from 10,613 lines to 9,405 lines)