### PR TITLE
Upgrade Fern toolchain

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "vital",
-  "version": "5.18.1"
+  "version": "5.95.0"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -23,7 +23,7 @@ groups:
   java-sdk:
     generators:
       - name: fernapi/fern-java-sdk
-        version: 4.8.3
+        version: 4.18.1
         autorelease: true
         output:
           location: maven
@@ -47,7 +47,7 @@ groups:
   node-sdk:
     generators:
       - name: fernapi/fern-typescript-sdk
-        version: 3.69.2
+        version: 3.78.1
         autorelease: true
         config:
           namespaceExport: Junction
@@ -72,7 +72,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 5.12.1
+        version: 5.27.1
         autorelease: true
         output:
           location: pypi
@@ -90,7 +90,7 @@ groups:
   go-sdk:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.40.2
+        version: 1.43.0
         autorelease: true
         github:
           repository: junction-api/junction-go
@@ -101,7 +101,7 @@ groups:
   postman:
     generators:
       - name: fernapi/fern-postman
-        version: 0.4.3
+        version: 0.6.1
         output:
           location: local-file-system
           path: ../postman


### PR DESCRIPTION
## Summary

- Upgrade the Fern CLI pin from 5.18.1 to 5.95.0 using `fern upgrade`, including its migrations.
- Upgrade Java to 4.18.1, Python to 5.27.1, and Postman to 0.6.1.
- Upgrade TypeScript to 3.78.1 and Go to 1.43.0, the newest versions verified not to change Junction's existing public SDK surface.

## Why

The configuration repository should track the CLI used for generation. Generator upgrades were reviewed against locally generated SDKs so this toolchain update does not introduce avoidable breaking changes.

TypeScript is intentionally capped before 3.78.2, which widens several generated public map value types with `| undefined`. Go is intentionally capped before 1.44.0, which makes two generated public structs non-comparable.

## Validation

- `fern check --warnings`: 0 errors; 14 existing route-conflict warnings
- Java: Gradle build/tests passed; japicmp found no source or binary incompatibilities
- Python: 75 tests passed, MyPy clean across 958 files, Ruff clean
- TypeScript: build passed; 605 unit tests passed; emitted declarations compared with the current pin
- Go: `go test ./...` passed; apidiff reported only compatible additions
- Postman: collection structure and request content preserved; optional query parameters are now disabled by default